### PR TITLE
Services refactor

### DIFF
--- a/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
+++ b/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.taxhistory
+
+import play.api.http.Status
+import play.api.libs.json.JsResultException
+import uk.gov.hmrc.http.HttpResponse
+
+case class TaxHistoryException(error: TaxHistoryError) extends Exception
+
+sealed trait TaxHistoryError
+
+final case class HttpNotOk(status: Int, response: HttpResponse) extends TaxHistoryError
+final case class JsonParsingError(jsonResultException: JsResultException) extends TaxHistoryError
+final case class UnknownError(throwable: Throwable) extends TaxHistoryError

--- a/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
+++ b/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
@@ -21,18 +21,22 @@ import uk.gov.hmrc.http.HttpResponse
 
 case class TaxHistoryException(error: TaxHistoryError, originator: Option[String] = None) extends Exception {
   override def getMessage: String = error.toString
-  override def toString: String = s"ApiException($error)"
+  override def toString: String = s"TaxHistoryException($error)"
 }
 
 object TaxHistoryException {
-  def notFound(itemType: Class[_], id: Any) = TaxHistoryException(NotFound(itemType, id))
+  def notFound(itemType: Class[_], id: Any): TaxHistoryException = TaxHistoryException(NotFound(itemType, id))
+  def serviceUnavailable: TaxHistoryException = TaxHistoryException(ServiceUnavailable)
+  def internalServerError: TaxHistoryException = TaxHistoryException(InternalServerError)
+  def badRequest: TaxHistoryException = TaxHistoryException(BadRequest)
 }
 
 sealed trait TaxHistoryError
 
 final case class NotFound(itemType: Class[_], id: Any) extends TaxHistoryError
 case object ServiceUnavailable extends TaxHistoryError
-final case class BadRequest(url: String) extends TaxHistoryError
-final case class HttpNotOk(status: Int, response: HttpResponse) extends TaxHistoryError
+case object InternalServerError extends TaxHistoryError
+case object BadRequest extends TaxHistoryError
+final case class GenericHttpError(status: Int, response: HttpResponse) extends TaxHistoryError
 final case class JsonParsingError(jsonResultException: JsResultException) extends TaxHistoryError
 final case class UnknownError(throwable: Throwable) extends TaxHistoryError

--- a/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
+++ b/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
@@ -19,13 +19,20 @@ package uk.gov.hmrc.taxhistory
 import play.api.libs.json.JsResultException
 import uk.gov.hmrc.http.HttpResponse
 
-case class TaxHistoryException(error: TaxHistoryError) extends Exception {
+case class TaxHistoryException(error: TaxHistoryError, originator: Option[String] = None) extends Exception {
   override def getMessage: String = error.toString
   override def toString: String = s"ApiException($error)"
 }
 
+object TaxHistoryException {
+  def notFound(itemType: Class[_], id: Any) = TaxHistoryException(NotFound(itemType, id))
+}
+
 sealed trait TaxHistoryError
 
+final case class NotFound(itemType: Class[_], id: Any) extends TaxHistoryError
+case object ServiceUnavailable extends TaxHistoryError
+final case class BadRequest(url: String) extends TaxHistoryError
 final case class HttpNotOk(status: Int, response: HttpResponse) extends TaxHistoryError
 final case class JsonParsingError(jsonResultException: JsResultException) extends TaxHistoryError
 final case class UnknownError(throwable: Throwable) extends TaxHistoryError

--- a/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
+++ b/app/uk/gov/hmrc/taxhistory/TaxHistoryError.scala
@@ -16,11 +16,13 @@
 
 package uk.gov.hmrc.taxhistory
 
-import play.api.http.Status
 import play.api.libs.json.JsResultException
 import uk.gov.hmrc.http.HttpResponse
 
-case class TaxHistoryException(error: TaxHistoryError) extends Exception
+case class TaxHistoryException(error: TaxHistoryError) extends Exception {
+  override def getMessage: String = error.toString
+  override def toString: String = s"ApiException($error)"
+}
 
 sealed trait TaxHistoryError
 

--- a/app/uk/gov/hmrc/taxhistory/connectors/BaseConnector.scala
+++ b/app/uk/gov/hmrc/taxhistory/connectors/BaseConnector.scala
@@ -20,7 +20,6 @@ import play.api.http.Status
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.config.{AppName, ServicesConfig}
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.taxhistory.auditable.Auditable
 import uk.gov.hmrc.taxhistory.metrics.{MetricsEnum, TaxHistoryMetrics}
 import uk.gov.hmrc.taxhistory.utils.TaxHistoryLogger
@@ -56,38 +55,4 @@ trait BaseConnector extends AnyRef with Auditable with TaxHistoryLogger {
 
   override def appName: String = AppName.appName
 
-  def getFromRTI(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
-    val timerContext = metrics.startTimer(MetricsEnum.RTI_GET_EMPLOYMENTS)
-
-    val futureResponse = httpGet.GET[HttpResponse](url)
-    futureResponse.flatMap {
-      timerContext.stop()
-      res =>
-        res.status match {
-          case Status.OK =>
-            metrics.incrementSuccessCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
-            Future.successful(res)
-          case Status.BAD_REQUEST =>
-            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
-            val errorMessage = s"RTIAPI - Bad Request error returned from RTI HODS"
-            logger.warn(errorMessage)
-            Future.successful(res)
-          case Status.NOT_FOUND =>
-            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
-            val errorMessage = s"RTIAPI - No DATA Found error returned from RTI HODS"
-            logger.warn(errorMessage)
-            Future.successful(res)
-          case Status.INTERNAL_SERVER_ERROR =>
-            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
-            val errorMessage = s"RTIAPI - Internal Server error returned from RTI HODS"
-            logger.warn(errorMessage)
-            Future.successful(res)
-          case status =>
-            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
-            val errorMessage = s"RTIAPI - An error returned from RTI HODS with status $status"
-            logger.warn(errorMessage)
-            Future.successful(res)
-        }
-    }
-  }
 }

--- a/app/uk/gov/hmrc/taxhistory/connectors/des/RtiConnector.scala
+++ b/app/uk/gov/hmrc/taxhistory/connectors/des/RtiConnector.scala
@@ -18,12 +18,16 @@ package uk.gov.hmrc.taxhistory.connectors.des
 
 import javax.inject.{Inject, Named}
 
+import play.api.http.Status
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.audit.model.Audit
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.taxhistory.connectors.BaseConnector
+import uk.gov.hmrc.taxhistory.metrics.MetricsEnum
 import uk.gov.hmrc.time.TaxYear
+
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
 import scala.concurrent.Future
 
@@ -53,5 +57,40 @@ class RtiConnector @Inject()(val httpGet: CoreGet,
   def getRTIEmployments(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     implicit val hc: HeaderCarrier = createHeader
     getFromRTI(rtiEmploymentsUrl(nino, taxYear))
+  }
+
+  def getFromRTI(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    val timerContext = metrics.startTimer(MetricsEnum.RTI_GET_EMPLOYMENTS)
+
+    val futureResponse = httpGet.GET[HttpResponse](url)
+    futureResponse.flatMap {
+      timerContext.stop()
+      res =>
+        res.status match {
+          case Status.OK =>
+            metrics.incrementSuccessCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
+            Future.successful(res)
+          case Status.BAD_REQUEST =>
+            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
+            val errorMessage = s"RTIAPI - Bad Request error returned from RTI HODS"
+            logger.warn(errorMessage)
+            Future.successful(res)
+          case Status.NOT_FOUND =>
+            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
+            val errorMessage = s"RTIAPI - No DATA Found error returned from RTI HODS"
+            logger.warn(errorMessage)
+            Future.successful(res)
+          case Status.INTERNAL_SERVER_ERROR =>
+            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
+            val errorMessage = s"RTIAPI - Internal Server error returned from RTI HODS"
+            logger.warn(errorMessage)
+            Future.successful(res)
+          case status =>
+            metrics.incrementFailedCounter(MetricsEnum.RTI_GET_EMPLOYMENTS)
+            val errorMessage = s"RTIAPI - An error returned from RTI HODS with status $status"
+            logger.warn(errorMessage)
+            Future.successful(res)
+        }
+    }
   }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/AllowanceController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/AllowanceController.scala
@@ -36,6 +36,7 @@ class AllowanceController @Inject()(val employmentHistoryService: EmploymentHist
     }
   }
 
-  private def retrieveAllowances(nino: String, taxYear: Int)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getAllowances(Nino(nino), TaxYear(taxYear)) map matchResponse
+  private def retrieveAllowances(nino: String, taxYear: Int)(implicit hc: HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getAllowances(Nino(nino), TaxYear(taxYear))
+  }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/AllowanceController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/AllowanceController.scala
@@ -20,9 +20,11 @@ import javax.inject.Inject
 
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
+import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
 
@@ -35,5 +37,5 @@ class AllowanceController @Inject()(val employmentHistoryService: EmploymentHist
   }
 
   private def retrieveAllowances(nino: String, taxYear: Int)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getAllowances(nino, taxYear) map matchResponse
+    employmentHistoryService.getAllowances(Nino(nino), TaxYear(taxYear)) map matchResponse
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitController.scala
@@ -37,6 +37,7 @@ class CompanyBenefitController @Inject()(val authConnector: AuthConnector,
     }
   }
 
-  private def retrieveCompanyBenefits(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getCompanyBenefits(nino, taxYear, employmentId) map matchResponse
+  private def retrieveCompanyBenefits(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getCompanyBenefits(nino, taxYear, employmentId)
+  }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitController.scala
@@ -20,9 +20,11 @@ import javax.inject.Inject
 
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
+import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
 
@@ -31,10 +33,10 @@ class CompanyBenefitController @Inject()(val authConnector: AuthConnector,
 
   def getCompanyBenefits(nino: String, taxYear: Int, employmentId: String): Action[AnyContent] = Action.async {
     implicit request => {
-      authorisedRelationship(nino, _ => retrieveCompanyBenefits(nino, taxYear, employmentId))
+      authorisedRelationship(nino, _ => retrieveCompanyBenefits(Nino(nino), TaxYear(taxYear), employmentId))
     }
   }
 
-  private def retrieveCompanyBenefits(nino: String, taxYear: Int, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
+  private def retrieveCompanyBenefits(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
     employmentHistoryService.getCompanyBenefits(nino, taxYear, employmentId) map matchResponse
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/EmploymentController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/EmploymentController.scala
@@ -20,9 +20,11 @@ import javax.inject.Inject
 
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
+import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
 
@@ -31,19 +33,19 @@ class EmploymentController @Inject()(val employmentHistoryService: EmploymentHis
 
   def getEmployments(nino: String, taxYear: Int): Action[AnyContent] = Action.async {
     implicit request => {
-      authorisedRelationship(nino, _ => retrieveEmployments(nino, taxYear))
+      authorisedRelationship(nino, _ => retrieveEmployments(Nino(nino), TaxYear(taxYear)))
     }
   }
 
   def getEmployment(nino: String, taxYear: Int, employmentId: String): Action[AnyContent] = Action.async {
     implicit request => {
-      authorisedRelationship(nino, _ => retrieveEmployment(nino, taxYear, employmentId))
+      authorisedRelationship(nino, _ => retrieveEmployment(Nino(nino), TaxYear(taxYear), employmentId))
     }
   }
 
-  private def retrieveEmployment(nino: String, taxYear: Int, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
+  private def retrieveEmployment(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
     employmentHistoryService.getEmployment(nino, taxYear, employmentId) map matchResponse
 
-  private def retrieveEmployments(nino: String, taxYear: Int)(implicit hc: HeaderCarrier): Future[Result] =
+  private def retrieveEmployments(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] =
     employmentHistoryService.getEmployments(nino, taxYear) map matchResponse
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/EmploymentController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/EmploymentController.scala
@@ -43,9 +43,11 @@ class EmploymentController @Inject()(val employmentHistoryService: EmploymentHis
     }
   }
 
-  private def retrieveEmployment(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getEmployment(nino, taxYear, employmentId) map matchResponse
+  private def retrieveEmployment(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc: HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getEmployment(nino, taxYear, employmentId)
+  }
 
-  private def retrieveEmployments(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getEmployments(nino, taxYear) map matchResponse
+  private def retrieveEmployments(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getEmployments(nino, taxYear)
+  }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/PayAndTaxController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/PayAndTaxController.scala
@@ -20,9 +20,11 @@ import javax.inject.Inject
 
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
+import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
 
@@ -31,10 +33,10 @@ class PayAndTaxController @Inject()(val authConnector: AuthConnector,
 
   def getPayAndTax(nino: String, taxYear: Int, employmentId: String): Action[AnyContent] = Action.async {
     implicit request => {
-      authorisedRelationship(nino, _ => retrievePayAndTax(nino, taxYear, employmentId))
+      authorisedRelationship(nino, _ => retrievePayAndTax(Nino(nino), TaxYear(taxYear), employmentId))
     }
   }
 
-  private def retrievePayAndTax(nino: String,taxYear: Int, employmentId: String)(implicit hc:HeaderCarrier): Future[Result] =
-    employmentHistoryService.getPayAndTax(nino = nino, taxYear = taxYear, employmentId = employmentId) map matchResponse
+  private def retrievePayAndTax(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc:HeaderCarrier): Future[Result] =
+    employmentHistoryService.getPayAndTax(nino, taxYear, employmentId) map matchResponse
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/PayAndTaxController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/PayAndTaxController.scala
@@ -37,6 +37,7 @@ class PayAndTaxController @Inject()(val authConnector: AuthConnector,
     }
   }
 
-  private def retrievePayAndTax(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc:HeaderCarrier): Future[Result] =
-    employmentHistoryService.getPayAndTax(nino, taxYear, employmentId) map matchResponse
+  private def retrievePayAndTax(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit hc:HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getPayAndTax(nino, taxYear, employmentId)
+  }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/TaxAccountController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/TaxAccountController.scala
@@ -20,9 +20,11 @@ import javax.inject.Inject
 
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
+import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
 
@@ -30,10 +32,10 @@ class TaxAccountController @Inject()(val authConnector: AuthConnector, val emplo
 
   def getTaxAccount(nino: String, taxYear: Int): Action[AnyContent] = Action.async {
     implicit request => {
-      authorisedRelationship(nino, _ => retrieveTaxAccount(nino, taxYear))
+      authorisedRelationship(nino, _ => retrieveTaxAccount(Nino(nino), TaxYear(taxYear)))
     }
   }
 
-  private def retrieveTaxAccount(nino: String, taxYear: Int)(implicit hc: HeaderCarrier): Future[Result] =
+  private def retrieveTaxAccount(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] =
     employmentHistoryService.getTaxAccount(nino, taxYear) map matchResponse
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/TaxAccountController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/TaxAccountController.scala
@@ -36,6 +36,7 @@ class TaxAccountController @Inject()(val authConnector: AuthConnector, val emplo
     }
   }
 
-  private def retrieveTaxAccount(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] =
-    employmentHistoryService.getTaxAccount(nino, taxYear) map matchResponse
+  private def retrieveTaxAccount(nino: Nino, taxYear: TaxYear)(implicit hc: HeaderCarrier): Future[Result] = toResult {
+    employmentHistoryService.getTaxAccount(nino, taxYear)
+  }
 }

--- a/app/uk/gov/hmrc/taxhistory/metrics/TaxHistoryMetrics.scala
+++ b/app/uk/gov/hmrc/taxhistory/metrics/TaxHistoryMetrics.scala
@@ -34,19 +34,19 @@ object TaxHistoryMetrics extends TaxHistoryMetrics with MicroserviceMetrics {
   val timers = Map(
     MetricsEnum.NPS_GET_EMPLOYMENTS -> registry.timer("nps-get-employments-response-timer"),
     MetricsEnum.RTI_GET_EMPLOYMENTS -> registry.timer("rti-get-employments-response-timer"),
-    MetricsEnum.NPS_GET_IABDS -> registry.timer("nps-get-iabds-response-timer"),
+    MetricsEnum.NPS_GET_IABDS       -> registry.timer("nps-get-iabds-response-timer"),
     MetricsEnum.NPS_GET_TAX_ACCOUNT -> registry.timer("nps-get-tax-account-response-timer")
   )
   val successCounters = Map(
     MetricsEnum.NPS_GET_EMPLOYMENTS -> registry.counter("nps-get-employments-success-counter"),
     MetricsEnum.RTI_GET_EMPLOYMENTS -> registry.counter("rti-get-employments-success-counter"),
-    MetricsEnum.NPS_GET_IABDS -> registry.counter("nps-get-iabds-success-counter"),
+    MetricsEnum.NPS_GET_IABDS       -> registry.counter("nps-get-iabds-success-counter"),
     MetricsEnum.NPS_GET_TAX_ACCOUNT -> registry.counter("nps-get-tax-account-success-counter")
   )
   val failedCounters = Map(
     MetricsEnum.NPS_GET_EMPLOYMENTS -> registry.counter("nps-get-employments-failed-counter"),
     MetricsEnum.RTI_GET_EMPLOYMENTS -> registry.counter("rti-get-employments-failed-counter"),
-    MetricsEnum.NPS_GET_IABDS -> registry.counter("nps-get-iabds-failed-counter"),
+    MetricsEnum.NPS_GET_IABDS       -> registry.counter("nps-get-iabds-failed-counter"),
     MetricsEnum.NPS_GET_TAX_ACCOUNT -> registry.counter("nps-get-tax-account-failed-counter")
   )
 

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -24,18 +24,18 @@ import play.api.libs.json.Reads._
 import play.api.libs.json.{JsPath, Reads, Writes}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
 
-case class Employment(employmentId:UUID = UUID.randomUUID(),
-                      startDate:LocalDate,
-                      endDate:Option[LocalDate] = None,
-                      payeReference:String,
-                      employerName:String,
-                      companyBenefitsURI:Option[String] = None,
-                      payAndTaxURI:Option[String] = None,
-                      employmentURI:Option[String] = None,
+case class Employment(employmentId: UUID = UUID.randomUUID(),
+                      startDate: LocalDate,
+                      endDate: Option[LocalDate] = None,
+                      payeReference: String,
+                      employerName: String,
+                      companyBenefitsURI: Option[String] = None,
+                      payAndTaxURI: Option[String] = None,
+                      employmentURI: Option[String] = None,
                       receivingOccupationalPension: Boolean = false,
                       employmentStatus: EmploymentStatus){
 
-  def enrichWithURIs(taxYear:Int):Employment = {
+  def enrichWithURIs(taxYear: Int): Employment = {
     val baseURI = s"/$taxYear/employments/${employmentId.toString}"
     this.copy(employmentURI = Some(baseURI),
               companyBenefitsURI = Some(baseURI + "/company-benefits"),

--- a/app/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarn.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarn.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.taxhistory.model.api
 import play.api.libs.json.Json
 
 
-case class PayAsYouEarn(employments :List[Employment]=Nil ,
-                        allowances: List[Allowance]=Nil ,
-                        benefits:Option[Map[String,List[CompanyBenefit]]]=None,
-                        payAndTax:Option[Map[String,PayAndTax]]=None,
-                        taxAccount:Option[TaxAccount]=None)
+case class PayAsYouEarn(employments: List[Employment] = Nil,
+                        allowances:  List[Allowance] = Nil,
+                        benefits:    Option[Map[String,List[CompanyBenefit]]] = None,
+                        payAndTax:   Option[Map[String,PayAndTax]] = None,
+                        taxAccount:  Option[TaxAccount] = None)
 
 object PayAsYouEarn {
   implicit val formats = Json.format[PayAsYouEarn]

--- a/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
@@ -18,7 +18,9 @@ package uk.gov.hmrc.taxhistory.model.nps
 
 import org.joda.time.LocalDate
 import play.api.libs.json._
+import uk.gov.hmrc.taxhistory.model.api.Employment
 import uk.gov.hmrc.taxhistory.model.utils.JsonUtils
+import uk.gov.hmrc.taxhistory.services.helpers.RtiDataHelper
 
 case class NpsEmployment(nino:String,
                       sequenceNumber:Int,
@@ -32,7 +34,21 @@ case class NpsEmployment(nino:String,
                       endDate: Option[LocalDate] = None,
                       receivingOccupationalPension:Boolean = false,
                       employmentStatus: EmploymentStatus
-                    )
+                    ) {
+
+  def payeRef: String = taxDistrictNumber + "/" + payeNumber
+
+  def toEmployment: Employment =
+    Employment(
+      employerName = employerName,
+      payeReference = payeRef,
+      startDate = startDate,
+      endDate = endDate,
+      receivingOccupationalPension = receivingOccupationalPension,
+      employmentStatus = employmentStatus
+    )
+
+}
 
 object NpsEmployment {
   implicit val reader = new Reads[NpsEmployment] {

--- a/app/uk/gov/hmrc/taxhistory/model/nps/NpsTaxAccount.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/nps/NpsTaxAccount.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.taxhistory.model.nps
 
 
 import play.api.libs.json._
+import uk.gov.hmrc.taxhistory.model.api.TaxAccount
 
 
 
@@ -56,7 +57,12 @@ case class NpsTaxAccount(incomeSources: List[IncomeSource]){
     incomeSources.find(_.employmentType==PrimaryEmployment).flatMap(_.actualPUPCodedInCYPlusOneTaxYear)
   }
 
-
+  def toTaxAccount: TaxAccount =
+    TaxAccount(
+      outstandingDebtRestriction = getOutStandingDebt,
+      underpaymentAmount = getUnderPayment,
+      actualPUPCodedInCYPlusOneTaxYear = getActualPupCodedInCYPlusOne
+    )
 }
 
 object NpsTaxAccount {

--- a/app/uk/gov/hmrc/taxhistory/package.scala
+++ b/app/uk/gov/hmrc/taxhistory/package.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+import _root_.play.api.libs.json.JsResultException
+import _root_.play.api.libs.json.Reads
+import _root_.play.api.http.Status
+import uk.gov.hmrc.http.HttpResponse
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+package object taxhistory {
+
+  implicit class HttpResponseFutureOps(responseFuture: Future[HttpResponse])(implicit ec: ExecutionContext) {
+    def decodeJsonOrError[A : Reads]: Future[A] = for {
+      response   <- responseFuture
+      okResponse <- response.expectOk
+      decoded    <- okResponse.decodeJsonOrError[A]
+    } yield {
+      decoded
+    }
+  }
+
+  implicit class HttpResponseOps(response: HttpResponse)(implicit ec: ExecutionContext) {
+    def expectOk: Future[HttpResponse] = {
+      if (response.status == Status.OK) {
+        Future.successful(response)
+      } else {
+        Future.failed(TaxHistoryException(HttpNotOk(response.status, response)))
+      }
+    }
+
+    def decodeJsonOrError[A : Reads]: Future[A] = {
+      if (response.status == Status.OK) {
+        Try(response.json.as[A]) match {
+          case Success(decoded)                        => Future.successful[A](decoded)
+          case Failure(jsException: JsResultException) => Future.failed[A](TaxHistoryException(JsonParsingError(jsException)))
+          case Failure(throwable)                      => Future.failed[A](TaxHistoryException(UnknownError(throwable)))
+        }
+      } else {
+        Future.failed[A](TaxHistoryException(HttpNotOk(response.status, response)))
+      }
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.audit.model.Audit
 import uk.gov.hmrc.tai.model.rti.RtiData
-import uk.gov.hmrc.taxhistory.{HttpNotOk, NotFound, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.{GenericHttpError, NotFound, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.auditable.Auditable
 import uk.gov.hmrc.taxhistory.connectors.des.RtiConnector
 import uk.gov.hmrc.taxhistory.connectors.nps.NpsConnector

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -73,7 +73,7 @@ class EmploymentHistoryService @Inject()(
 
 
   def getFromCache(nino: Nino, taxYear: TaxYear)(implicit headerCarrier: HeaderCarrier): Future[PayAsYouEarn] = {
-    cacheService.getOrElseInsert[PayAsYouEarn](nino, taxYear) {
+    cacheService.getOrElseInsert(nino, taxYear) {
       retrieveEmploymentsDirectFromSource(nino, taxYear).map { h =>
         logger.warn(s"Refreshing cached data for $nino $taxYear")
         h

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/EmploymentHistoryServiceHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/EmploymentHistoryServiceHelper.scala
@@ -26,15 +26,11 @@ import uk.gov.hmrc.taxhistory.model.nps._
 
 trait EmploymentHistoryServiceHelper extends TaxHistoryHelper with Auditable {
 
-  def combineResult(iabdResponse: Either[HttpResponse,List[Iabd]],
-                    rtiResponse: Either[HttpResponse,RtiData],
-                    taxAccResponse: Either[HttpResponse,Option[NpsTaxAccount]])
+  def combineResult(iabdsOption: Option[List[Iabd]],
+                    rtiOption: Option[RtiData],
+                    taxAccOption: Option[Option[NpsTaxAccount]])
                    (npsEmployments: List[NpsEmployment])
                    (implicit headerCarrier: HeaderCarrier): PayAsYouEarn = {
-
-    val iabdsOption  = iabdResponse.right.toOption
-    val rtiOption    = rtiResponse.right.toOption
-    val taxAccOption = taxAccResponse.right.toOption
 
     val payAsYouEarnList = npsEmployments.map { npsEmployment =>
       val companyBenefits = iabdsOption.map { iabds =>

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/IabdsHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/IabdsHelper.scala
@@ -20,31 +20,18 @@ import uk.gov.hmrc.taxhistory.model.api.{Allowance, CompanyBenefit}
 import uk.gov.hmrc.taxhistory.model.nps._
 import uk.gov.hmrc.taxhistory.utils.TaxHistoryLogger
 
-class IabdsHelper(val iabds:List[Iabd]) extends TaxHistoryHelper with TaxHistoryLogger{
+class IabdsHelper(val iabds: List[Iabd]) extends TaxHistoryHelper with TaxHistoryLogger{
 
+  def getRawCompanyBenefits(): List[Iabd] = iabds.filter(_.`type`.isInstanceOf[CompanyBenefits])
 
-
-  def getRawCompanyBenefits(): List[Iabd] = {
-    iabds.filter {
-      iabd => {
-        iabd.`type`.isInstanceOf[CompanyBenefits]
-      }
-    }
-  }
-
-  def getMatchedCompanyBenefits(npsEmployment: NpsEmployment):List[Iabd] = {
-    getRawCompanyBenefits().filter {
-      (iabd) => {
-        iabd.employmentSequenceNumber.contains(npsEmployment.sequenceNumber)
-      }
-    }
-  }
+  def getMatchedCompanyBenefits(npsEmployment: NpsEmployment):List[Iabd] =
+    getRawCompanyBenefits().filter(_.employmentSequenceNumber.contains(npsEmployment.sequenceNumber))
 
 
   def getCompanyBenefits():List[CompanyBenefit] = {
     if (isTotalBenefitInKind()) {
       convertToCompanyBenefits(this.iabds)
-    }else{
+    } else {
       convertToCompanyBenefits(iabds.filter {
         iabd => {
           !iabd.`type`.isInstanceOf[TotalBenefitInKind.type]
@@ -55,41 +42,25 @@ class IabdsHelper(val iabds:List[Iabd]) extends TaxHistoryHelper with TaxHistory
   }
 
   private def convertToCompanyBenefits(iabds:List[Iabd]):List[CompanyBenefit]= {
-    iabds.map {
-      iabd =>
-        CompanyBenefit(
-          amount = iabd.grossAmount.fold {
-            logger.warn("Iabds grossAmount is blank")
-            BigDecimal(0)
-          }(x => x),
-          iabdType = iabd.`type`.toString,
-          source = iabd.source
-        )
+    iabds.map { iabd =>
+      CompanyBenefit(
+        amount = iabd.grossAmount.fold {
+          logger.warn("Iabds grossAmount is blank")
+          BigDecimal(0)
+        }(x => x),
+        iabdType = iabd.`type`.toString,
+        source = iabd.source
+      )
     }
   }
 
-  def isTotalBenefitInKind():Boolean = {
-    iabds.exists {
-      iabd => {
-        iabd.`type`.isInstanceOf[TotalBenefitInKind.type]
-      }
-    } &&
-      iabds.count {
-        iabd => {
-          iabd.`type`.isInstanceOf[uk.gov.hmrc.taxhistory.model.nps.BenefitInKind]
-        }
-      } == 1
+  def isTotalBenefitInKind(): Boolean = {
+    iabds.exists(_.`type`.isInstanceOf[TotalBenefitInKind.type]) &&
+      iabds.count(_.`type`.isInstanceOf[uk.gov.hmrc.taxhistory.model.nps.BenefitInKind]) == 1
   }
 
 
-  def getRawAllowances():List[Iabd] = {
-
-    iabds.filter {
-      iabd => {
-        iabd.`type`.isInstanceOf[Allowances]
-      }
-    }
-  }
+  def getRawAllowances():List[Iabd] = iabds.filter(_.`type`.isInstanceOf[Allowances])
 
 
   def getAllowances():List[Allowance] = {

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/RtiDataHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/RtiDataHelper.scala
@@ -89,13 +89,13 @@ class RtiDataHelper(val rtiData: RtiData) extends TaxHistoryHelper with TaxHisto
 
 object RtiDataHelper {
 
-  def convertToPayAndTax(rtiEmployments: List[RtiEmployment]): PayAndTax ={
+  def convertToPayAndTax(rtiEmployments: List[RtiEmployment]): PayAndTax = {
     val employment = rtiEmployments.head
     val eyuList = convertRtiEYUToEYU(employment)
     employment.payments match {
       case Nil => PayAndTax(earlierYearUpdates = eyuList)
       case matchingPayments => {
-        val payment =matchingPayments.sorted.last
+        val payment = matchingPayments.sorted.last
         PayAndTax(taxablePayTotal = Some(payment.taxablePayYTD),
           taxTotal = Some(payment.totalTaxYTD),
           paymentDate=Some(payment.paidOnDate),
@@ -107,10 +107,10 @@ object RtiDataHelper {
   def convertRtiEYUToEYU(rtiEmployment: RtiEmployment): List[EarlierYearUpdate] = {
     rtiEmployment.earlierYearUpdates.map(eyu => {
       EarlierYearUpdate(
-        taxablePayEYU =  eyu.taxablePayDelta,
+        taxablePayEYU = eyu.taxablePayDelta,
         taxEYU = eyu.totalTaxDelta,
         receivedDate = eyu.receivedDate)
-    }).filter(x =>x.taxablePayEYU != 0 && x.taxEYU != 0)
+    }).filter(x => x.taxablePayEYU != 0 && x.taxEYU != 0)
   }
 
   def getPayeRef(npsEmployment: NpsEmployment) = {

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/RtiDataHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/RtiDataHelper.scala
@@ -112,8 +112,4 @@ object RtiDataHelper {
         receivedDate = eyu.receivedDate)
     }).filter(x => x.taxablePayEYU != 0 && x.taxEYU != 0)
   }
-
-  def getPayeRef(npsEmployment: NpsEmployment) = {
-    npsEmployment.taxDistrictNumber + "/" + npsEmployment.payeNumber
-  }
 }

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/TaxHistoryHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/TaxHistoryHelper.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.taxhistory.services.helpers
 
 import scala.util.{Failure, Success, Try}
 
-trait TaxHistoryHelper  {
+trait TaxHistoryHelper {
 
-  def formatString(a: String):String = {
+  def formatString(a: String): String = {
     Try(a.toInt) match {
       case Success(x) => x.toString
       case Failure(y) => a

--- a/test/uk/gov/hmrc/taxhistory/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/connectors/NpsConnectorSpec.scala
@@ -26,11 +26,11 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
 import uk.gov.hmrc.play.audit.model.Audit
 import uk.gov.hmrc.play.config.ServicesConfig
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.connectors.nps.NpsConnector
 import uk.gov.hmrc.taxhistory.metrics.TaxHistoryMetrics
 import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
+import uk.gov.hmrc.taxhistory.{BadRequest, GenericHttpError, ServiceUnavailable, TaxHistoryException}
 
 import scala.concurrent.Future
 
@@ -93,7 +93,7 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testemploymentsConnector.getEmployments(testNino, testYear)
 
         intercept[Exception] (await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
+          case TaxHistoryException(BadRequest, _) =>
         }
       }
     }
@@ -127,7 +127,7 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testIabdsConnector.getIabds(testNino, testYear)
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, _), _) =>
+          case TaxHistoryException(ServiceUnavailable, _) =>
         }
       }
     }
@@ -154,12 +154,12 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         when(testTaxAccountConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
 
         when(testTaxAccountConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
-          .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+          .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
         val result = testTaxAccountConnector.getTaxAccount(testNino, testYear)
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
+          case TaxHistoryException(BadRequest, _) =>
         }
       }
     }

--- a/test/uk/gov/hmrc/taxhistory/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/connectors/NpsConnectorSpec.scala
@@ -93,7 +93,7 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testemploymentsConnector.getEmployments(testNino, testYear)
 
         intercept[Exception] (await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _)) =>
+          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
         }
       }
     }
@@ -127,7 +127,7 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testIabdsConnector.getIabds(testNino, testYear)
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, _)) =>
+          case TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, _), _) =>
         }
       }
     }
@@ -159,7 +159,7 @@ class NpsConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testTaxAccountConnector.getTaxAccount(testNino, testYear)
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _)) =>
+          case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
         }
       }
     }

--- a/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
@@ -88,7 +88,7 @@ class RtiConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, _)) =>
+          case TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, _), _) =>
         }
       }
 

--- a/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
@@ -21,11 +21,14 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
+import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
 import uk.gov.hmrc.play.audit.model.Audit
 import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.tai.model.rti.RtiData
+import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.connectors.des.RtiConnector
 import uk.gov.hmrc.taxhistory.metrics.TaxHistoryMetrics
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -71,64 +74,24 @@ class RtiConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any())).thenReturn(Future.successful(fakeResponse))
 
         val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
-        val rtiDataResponse = await(result)
 
-        rtiDataResponse.status mustBe OK
-        rtiDataResponse.json mustBe rtiSuccessfulResponseURLDummy
+        await(result) mustBe rtiSuccessfulResponseURLDummy.as[RtiData]
       }
-    }
-    "return and handle a bad request response " in {
-      val expectedResponse = Json.parse( """{"reason": "Some thing went wrong"}""")
-      implicit val hc = HeaderCarrier()
-      when(testRtiConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
+      "return and handle an error response" in {
+        val expectedResponse = Json.parse( """{"reason": "Internal Server Error"}""")
+        implicit val hc = HeaderCarrier()
+        when(testRtiConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
 
-      when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
-        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(expectedResponse))))
+        when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
+          .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(expectedResponse))))
 
-      val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
-      val response = await(result)
-      response.status must be(BAD_REQUEST)
-      response.json must be(expectedResponse)
-    }
-    "return and handle a not found response " in {
-      val expectedResponse = Json.parse( """{"reason": "Resource not found"}""")
-      implicit val hc = HeaderCarrier()
+        val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
 
-      when(testRtiConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
+        intercept[Exception](await(result)) must matchPattern {
+          case TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, _)) =>
+        }
+      }
 
-      when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
-        .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(expectedResponse))))
-
-      val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
-      val response = await(result)
-      response.status mustBe NOT_FOUND
-      response.json mustBe expectedResponse
-    }
-    "return and handle an internal server error response " in {
-      val expectedResponse = Json.parse( """{"reason": "Internal Server Error"}""")
-      implicit val hc = HeaderCarrier()
-      when(testRtiConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
-
-      when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
-        .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(expectedResponse))))
-
-      val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
-      val response = await(result)
-      response.status mustBe INTERNAL_SERVER_ERROR
-      response.json mustBe expectedResponse
-    }
-    "return and handle an service unavailable error response " in {
-      val expectedResponse = Json.parse( """{"reason": "Service Unavailable Error"}""")
-      implicit val hc = HeaderCarrier()
-      when(testRtiConnector.metrics.startTimer(any())).thenReturn(new Timer().time())
-
-      when(testRtiConnector.httpGet.GET[HttpResponse](any())(any(), any(), any()))
-        .thenReturn(Future.successful(HttpResponse(SERVICE_UNAVAILABLE, Some(expectedResponse))))
-
-      val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
-      val response = await(result)
-      response.status mustBe SERVICE_UNAVAILABLE
-      response.json mustBe expectedResponse
     }
   }
 

--- a/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/connectors/RtiConnectorSpec.scala
@@ -21,17 +21,16 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
 import uk.gov.hmrc.play.audit.model.Audit
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.tai.model.rti.RtiData
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.connectors.des.RtiConnector
 import uk.gov.hmrc.taxhistory.metrics.TaxHistoryMetrics
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
+import uk.gov.hmrc.taxhistory.{GenericHttpError, InternalServerError, TaxHistoryException}
 import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
@@ -66,6 +65,7 @@ class RtiConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
     }
 
     "get RTI data " when {
+
       "given a valid Nino and TaxYear" in {
         implicit val hc = HeaderCarrier()
         val fakeResponse: HttpResponse = HttpResponse(OK, Some(rtiSuccessfulResponseURLDummy))
@@ -77,6 +77,7 @@ class RtiConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
 
         await(result) mustBe rtiSuccessfulResponseURLDummy.as[RtiData]
       }
+
       "return and handle an error response" in {
         val expectedResponse = Json.parse( """{"reason": "Internal Server Error"}""")
         implicit val hc = HeaderCarrier()
@@ -88,10 +89,9 @@ class RtiConnectorSpec extends PlaySpec with MockitoSugar with TestUtil {
         val result = testRtiConnector.getRTIEmployments(testNino, TaxYear(2016))
 
         intercept[Exception](await(result)) must matchPattern {
-          case TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, _), _) =>
+          case TaxHistoryException(InternalServerError, _) =>
         }
       }
-
     }
   }
 

--- a/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
@@ -26,8 +26,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.Allowance
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
@@ -90,7 +90,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -100,7 +100,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
       val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -110,7 +110,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
@@ -80,7 +80,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[Allowance], "")))
       val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/AllowanceControllerSpec.scala
@@ -36,7 +36,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino =randomNino.toString()
+  private val nino = randomNino()
   private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
   private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
   private val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
@@ -65,7 +65,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -75,7 +75,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
 
@@ -85,7 +85,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
 
@@ -95,7 +95,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
 
@@ -105,7 +105,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -116,7 +116,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -127,7 +127,7 @@ class AllowanceControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
       when(mockEmploymentHistoryService.getAllowances(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testAllowanceController.getAllowances(nino, 2016).apply(FakeRequest())
+      val result = testAllowanceController.getAllowances(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.Future
 class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with MockitoSugar with TestUtil with BeforeAndAfterEach  {
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino =randomNino.toString
+  private val nino = randomNino()
   private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
   private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
   private val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
@@ -67,7 +67,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -77,7 +77,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
 
@@ -87,7 +87,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
 
@@ -97,7 +97,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
 
@@ -107,7 +107,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -118,7 +118,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
 
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -129,7 +129,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
 
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testCompanyBenefitController.getCompanyBenefits(nino, 2016, employmentId).apply(FakeRequest())
+      val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
@@ -81,7 +81,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[CompanyBenefit], "")))
       val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/CompanyBenefitControllerSpec.scala
@@ -28,8 +28,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.CompanyBenefit
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
@@ -91,7 +91,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -101,7 +101,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
       val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -111,7 +111,7 @@ class CompanyBenefitControllerSpec extends PlaySpec with OneServerPerSuite with 
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getCompanyBenefits(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testCompanyBenefitController.getCompanyBenefits(nino.nino, 2016, employmentId).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
@@ -82,7 +82,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[Employment], "")))
       val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
@@ -157,7 +157,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[Employment], "")))
       val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
@@ -36,7 +36,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
 
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino =randomNino.toString()
+  private val nino = randomNino()
   private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
   private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
   private val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
@@ -65,7 +65,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2016).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2016).apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -75,7 +75,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
 
@@ -85,7 +85,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
 
@@ -95,7 +95,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
 
@@ -105,7 +105,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -116,7 +116,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
 
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -127,7 +127,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
 
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployments(nino, 2015).apply(FakeRequest())
+      val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }
@@ -140,7 +140,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2016,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2016,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -150,7 +150,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
 
@@ -160,7 +160,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
 
@@ -170,7 +170,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
 
@@ -180,7 +180,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -191,7 +191,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
 
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -202,7 +202,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
 
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testEmploymentController.getEmployment(nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
+      val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/EmploymentControllerSpec.scala
@@ -27,8 +27,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.Employment
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -92,7 +92,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -102,7 +102,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
       val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -112,7 +112,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testEmploymentController.getEmployments(nino.nino, 2015).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
@@ -167,7 +167,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -177,7 +177,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
       val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -187,7 +187,7 @@ class EmploymentControllerSpec extends PlaySpec with OneServerPerSuite with Mock
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getEmployment(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testEmploymentController.getEmployment(nino.nino, 2015,"ba047b92-6899-4bf8-819a-820fc0dd2703").apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/IndividualTaxYearControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/IndividualTaxYearControllerSpec.scala
@@ -26,11 +26,11 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.{Audit, DataEvent}
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.IndividualTaxYear
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
 
@@ -84,7 +84,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxYears(Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testIndividualTaxYearController.getTaxYears(nino.nino).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/IndividualTaxYearControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/IndividualTaxYearControllerSpec.scala
@@ -38,7 +38,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
 
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino =randomNino.toString()
+  private val nino = randomNino()
   object MockAudit extends Audit("mockApp", mock[AuditConnector]) {
     override def sendDataEvent: (DataEvent) => Unit =
       _ => {}
@@ -71,7 +71,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxYears(Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testIndividualTaxYearController.getTaxYears(nino).apply(FakeRequest())
+      val result = testIndividualTaxYearController.getTaxYears(nino.nino).apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -81,7 +81,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxYears(Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testIndividualTaxYearController.getTaxYears(nino).apply(FakeRequest())
+      val result = testIndividualTaxYearController.getTaxYears(nino.nino).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -92,7 +92,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
 
       when(mockEmploymentHistoryService.getTaxYears(Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testIndividualTaxYearController.getTaxYears(nino).apply(FakeRequest())
+      val result = testIndividualTaxYearController.getTaxYears(nino.nino).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -103,7 +103,7 @@ class IndividualTaxYearControllerSpec extends PlaySpec with OneServerPerSuite wi
 
       when(mockEmploymentHistoryService.getTaxYears(Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testIndividualTaxYearController.getTaxYears(nino).apply(FakeRequest())
+      val result = testIndividualTaxYearController.getTaxYears(nino.nino).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
@@ -29,6 +29,8 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.model.api.PayAndTax
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
 
@@ -36,14 +38,17 @@ import scala.concurrent.Future
 
 class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with MockitoSugar with TestUtil with BeforeAndAfterEach {
 
-  private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
-  private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino = randomNino()
-  private val taxYear = 2016
-  private val employmentId=UUID.randomUUID().toString
-  private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
-  private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
-  private val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
+  val mockEmploymentHistoryService = mock[EmploymentHistoryService]
+  val mockPlayAuthConnector = mock[PlayAuthConnector]
+  val nino = randomNino()
+  val taxYear = 2016
+  val employmentId=UUID.randomUUID().toString
+
+  val testPayAndTax = PayAndTax(earlierYearUpdates = Nil)
+
+  lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
+  val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
+  val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
 
   val newEnrolments = Set(
     Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", "TestArn")), state="",delegatedAuthRule = None)
@@ -67,7 +72,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
+        .thenReturn(Future.successful(testPayAndTax))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(OK)
     }
@@ -77,7 +82,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
@@ -87,7 +92,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -97,7 +102,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -107,7 +112,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
@@ -118,7 +123,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(UnAuthorisedAgentEnrolments))))
 
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
+        .thenReturn(Future.successful(testPayAndTax))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
@@ -129,7 +134,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](None, Enrolments(UnAuthorisedAgentEnrolments))))
 
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
+        .thenReturn(Future.successful(testPayAndTax))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
@@ -82,7 +82,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[PayAndTax], "")))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
@@ -28,8 +28,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.PayAndTax
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
@@ -92,7 +92,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
@@ -102,7 +102,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
@@ -112,7 +112,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
       (Matchers.any(),Matchers.any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
       val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/PayAndTaxControllerSpec.scala
@@ -38,8 +38,8 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino =randomNino.toString()
-  private val taxYear=2016
+  private val nino = randomNino()
+  private val taxYear = 2016
   private val employmentId=UUID.randomUUID().toString
   private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
   private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
@@ -68,7 +68,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(OK)
     }
 
@@ -78,7 +78,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(NOT_FOUND)
     }
 
@@ -88,7 +88,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(BAD_REQUEST)
     }
 
@@ -98,7 +98,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future. successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(SERVICE_UNAVAILABLE)
     }
 
@@ -108,7 +108,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent) , Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(INTERNAL_SERVER_ERROR)
     }
 
@@ -119,7 +119,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
 
@@ -130,7 +130,7 @@ class PayAndTaxControllerSpec extends PlaySpec with OneServerPerSuite with Mocki
 
       when(mockEmploymentHistoryService.getPayAndTax(Matchers.any(),Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
-      val result = testPayAndTaxController.getPayAndTax(nino, taxYear, employmentId).apply(FakeRequest())
+      val result = testPayAndTaxController.getPayAndTax(nino.nino, taxYear, employmentId).apply(FakeRequest())
       status(result) must be(UNAUTHORIZED)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
@@ -26,6 +26,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -38,7 +39,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
 
   private val mockEmploymentHistoryService = mock[EmploymentHistoryService]
   private val mockPlayAuthConnector = mock[PlayAuthConnector]
-  private val nino = randomNino.toString()
+  private val nino = randomNino()
   private lazy val successResponseJson = Json.parse( """{"test":"OK"}""")
   private val failureResponseJson = Json.parse( """{"reason":"Resource not found"}""")
   private val errorResponseJson = Json.parse( """{"reason":"Some error."}""")
@@ -66,70 +67,70 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
     "respond with OK for successful get" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe OK
     }
 
     "respond with NOT_FOUND, for unsuccessful GET" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, Some(failureResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe NOT_FOUND
     }
 
     "respond with BAD_REQUEST, if HODS/Downstream sends BadRequest status" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(errorResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe BAD_REQUEST
     }
 
     "respond with SERVICE_UNAVAILABLE, if HODS/Downstream is unavailable" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(SERVICE_UNAVAILABLE, Some(errorResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe SERVICE_UNAVAILABLE
     }
 
     "respond with INTERNAL_SERVER_ERROR, if HODS/Downstream sends some server error response" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, Some(errorResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe INTERNAL_SERVER_ERROR
     }
 
     "respond with UNAUTHORIZED Status for enrolments which is not HMRC Agent" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(UnAuthorisedAgentEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe UNAUTHORIZED
     }
 
     "respond with UNAUTHORIZED Status where affinity group is not retrieved" in {
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](None, Enrolments(UnAuthorisedAgentEnrolments))))
-      when(mockEmploymentHistoryService.getTaxAccount(any[String], any[Int])(any[HeaderCarrier]))
+      when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(successResponseJson))))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe UNAUTHORIZED
     }
 
@@ -137,7 +138,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.failed(new InsufficientEnrolments))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe UNAUTHORIZED
     }
 
@@ -145,7 +146,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.failed(new MissingBearerToken))
 
-      val result = testTaxAccountController.getTaxAccount(nino, testTaxYear).apply(FakeRequest())
+      val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe INTERNAL_SERVER_ERROR
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
@@ -82,7 +82,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[TaxAccount], "")))
 
       val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe NOT_FOUND

--- a/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
@@ -27,9 +27,9 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.TaxAccount
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
@@ -92,7 +92,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe BAD_REQUEST
@@ -102,7 +102,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(SERVICE_UNAVAILABLE, HttpResponse(SERVICE_UNAVAILABLE)))))
+        .thenReturn(Future.failed(TaxHistoryException.serviceUnavailable))
 
       val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe SERVICE_UNAVAILABLE
@@ -112,7 +112,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
       when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any()))
         .thenReturn(Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Agent), Enrolments(newEnrolments))))
       when(mockEmploymentHistoryService.getTaxAccount(any[Nino], any[TaxYear])(any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(INTERNAL_SERVER_ERROR, HttpResponse(INTERNAL_SERVER_ERROR)))))
+        .thenReturn(Future.failed(TaxHistoryException.internalServerError))
 
       val result = testTaxAccountController.getTaxAccount(nino.nino, testTaxYear).apply(FakeRequest())
       status(result) shouldBe INTERNAL_SERVER_ERROR

--- a/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
@@ -23,9 +23,9 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tai.model.rti.RtiEmployment
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.{Allowance, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil

--- a/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -92,7 +93,7 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getAllowances("AA000000A", 2014))
+      val result = await(testEmploymentHistoryService.getAllowances(Nino("AA000000A"), TaxYear(2014)))
       result.json must be(allowanceJson)
     }
 
@@ -105,7 +106,7 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getAllowances("AA000000A", 2014))
+      val result = await(testEmploymentHistoryService.getAllowances(Nino("AA000000A"), TaxYear(2014)))
       result.status must be(NOT_FOUND)
       result.json must be(allowanceJson)
     }

--- a/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
@@ -70,7 +71,7 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND)))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(NOT_FOUND)))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
       val response =  await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))
       response mustBe a[HttpResponse]
       response.status mustBe OK

--- a/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
@@ -24,9 +24,10 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.tai.model.rti.RtiEmployment
 import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.{Allowance, PayAsYouEarn}
-import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment}
+import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -72,9 +73,9 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(iabdsResponse))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[NpsTaxAccount], "")))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[RtiEmployment], "")))
       val response =  await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))
 
       val allowances = response.allowances

--- a/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/AllowancesServiceSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
+import uk.gov.hmrc.taxhistory.model.nps.NpsEmployment
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -42,21 +43,22 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
 
   val failureResponseJson = Json.parse("""{"reason":"Bad Request"}""")
 
-  val npsEmploymentResponse =  Json.parse(""" [{
-                             |    "nino": "AA000000",
-                             |    "sequenceNumber": 1,
-                             |    "worksNumber": "6044041000000",
-                             |    "taxDistrictNumber": "531",
-                             |    "payeNumber": "J4816",
-                             |    "employerName": "Aldi",
-                             |    "receivingJobseekersAllowance" : false,
-                             |    "otherIncomeSourceIndicator" : false,
-                             |    "receivingOccupationalPension": true,
-                             |    "employmentStatus": 1,
-                             |    "startDate": "21/01/2015"
-                             |    }]
-                           """.stripMargin)
+  val npsEmploymentResponseJson =  Json.parse(""" [{
+                                     |    "nino": "AA000000",
+                                     |    "sequenceNumber": 1,
+                                     |    "worksNumber": "6044041000000",
+                                     |    "taxDistrictNumber": "531",
+                                     |    "payeNumber": "J4816",
+                                     |    "employerName": "Aldi",
+                                     |    "receivingJobseekersAllowance" : false,
+                                     |    "otherIncomeSourceIndicator" : false,
+                                     |    "receivingOccupationalPension": true,
+                                     |    "employmentStatus": 1,
+                                     |    "startDate": "21/01/2015"
+                                     |    }]
+                                   """.stripMargin)
 
+  val npsEmploymentResponse = npsEmploymentResponseJson.as[List[NpsEmployment]]
 
   lazy val iabdsJsonResponse = loadFile("/json/nps/response/iabds.json")
 
@@ -65,7 +67,7 @@ class AllowancesServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
   "Allowances " should {
     "successfully  populated  from iabds" in {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(npsEmploymentResponse))))
+        .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(iabdsJsonResponse))))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
@@ -21,17 +21,17 @@ import org.mockito.Matchers
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import play.api.libs.json.{JsArray, Json}
+import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tai.model.rti.{RtiData, RtiEmployment}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, NotFound, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, Employment, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.{EmploymentStatus, Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.helpers.RtiDataHelper
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
+import uk.gov.hmrc.taxhistory.{BadRequest, NotFound, TaxHistoryException}
 import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
@@ -199,10 +199,10 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
 
     "return any non success status response from get Nps Employments api" in {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsEmployments(testNino, TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
+        case TaxHistoryException(BadRequest, _) =>
       }
     }
 
@@ -226,11 +226,11 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       noException shouldBe thrownBy {
         await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))
@@ -245,7 +245,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(rtiEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       val paye = await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))
 
@@ -367,10 +367,10 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
 
     "return any non success status response from get Nps Iabds api" in {
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsIabds(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
+        case TaxHistoryException(BadRequest, _) =>
       }
     }
 
@@ -381,10 +381,10 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
 
     "return any non success status response from get Nps Tax Account api" in {
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsTaxAccount(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
+        case TaxHistoryException(BadRequest, _) =>
       }
     }
 

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.tai.model.rti.{RtiData, RtiEmployment}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.{HttpNotOk, NotFound, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, Employment, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.{EmploymentStatus, Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -218,7 +218,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(Nil))
       intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+        case TaxHistoryException(NotFound(_, _), _) =>
       }
     }
 
@@ -332,7 +332,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+          case TaxHistoryException(NotFound(_, _), _) =>
         }
       }
     }
@@ -347,7 +347,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+          case TaxHistoryException(NotFound(_, _), _) =>
         }
       }
 
@@ -360,7 +360,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+          case TaxHistoryException(NotFound(_, _), _) =>
         }
       }
     }
@@ -393,7 +393,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[NpsTaxAccount], "")))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsTaxAccount(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+        case TaxHistoryException(NotFound(_, _), _) =>
       }
     }
 
@@ -478,7 +478,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(paye))
 
       intercept[Exception](await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), TaxYear(2014)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+        case TaxHistoryException(NotFound(_, _), _) =>
       }
     }
 
@@ -516,7 +516,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(paye))
 
       intercept[Exception](await(testEmploymentHistoryService.getEmployment(Nino("AA000000A"), TaxYear(2014),"01318d7c-bcd9-47e2-8c38-551e7ccdfae6"))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+        case TaxHistoryException(NotFound(_, _), _) =>
       }
     }
 
@@ -546,7 +546,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(payeNoBenefits))
 
       intercept[Exception](await(testEmploymentHistoryService.getCompanyBenefits(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
+        case TaxHistoryException(NotFound(_, _), _) =>
       }
 
     }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
@@ -202,7 +202,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsEmployments(testNino, TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _)) =>
+        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
       }
     }
 
@@ -218,7 +218,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(Nil))
       intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
       }
     }
 
@@ -332,7 +332,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
         }
       }
     }
@@ -347,7 +347,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
         }
       }
 
@@ -360,7 +360,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
           .thenReturn(Future.successful(rtiEmploymentResponse))
 
         intercept[Exception](await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))) must matchPattern {
-          case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+          case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
         }
       }
     }
@@ -370,7 +370,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsIabds(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _)) =>
+        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
       }
     }
 
@@ -384,16 +384,16 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsTaxAccount(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _)) =>
+        case TaxHistoryException(HttpNotOk(BAD_REQUEST, _), _) =>
       }
     }
 
     "return not found status response from get Nps Tax Account api" in {
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[NpsTaxAccount], "")))
 
       intercept[Exception](await(testEmploymentHistoryService.getNpsTaxAccount(testNino,TaxYear(2016)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
       }
     }
 
@@ -478,7 +478,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(paye))
 
       intercept[Exception](await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), TaxYear(2014)))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
       }
     }
 
@@ -516,7 +516,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(paye))
 
       intercept[Exception](await(testEmploymentHistoryService.getEmployment(Nino("AA000000A"), TaxYear(2014),"01318d7c-bcd9-47e2-8c38-551e7ccdfae6"))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
       }
     }
 
@@ -546,7 +546,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
         .thenReturn(Future.successful(payeNoBenefits))
 
       intercept[Exception](await(testEmploymentHistoryService.getCompanyBenefits(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))) must matchPattern {
-        case TaxHistoryException(HttpNotOk(NOT_FOUND, _)) =>
+        case TaxHistoryException(HttpNotOk(NOT_FOUND, _), _) =>
       }
 
     }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsArray, Json}
 import play.api.test.Helpers._
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.tai.model.rti.{RtiData, RtiEmployment}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
@@ -468,7 +469,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
               .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getEmployments("AA000000A", 2014))
+      val result = await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), TaxYear(2014)))
       result.json must be (employmentsJson)
     }
 
@@ -480,7 +481,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getEmployments("AA000000A", 2014))
+      val result = await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), TaxYear(2014)))
       result.status must be (NOT_FOUND)
     }
 
@@ -506,7 +507,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getEmployment("AA000000A", 2014,"01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
+      val result = await(testEmploymentHistoryService.getEmployment(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
       result.json must be (employmentJson)
       result.status must be (OK)
     }
@@ -528,7 +529,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getEmployment("AA000000A", 2014,"01318d7c-bcd9-47e2-8c38-551e7ccdfae6"))
+      val result = await(testEmploymentHistoryService.getEmployment(Nino("AA000000A"), TaxYear(2014),"01318d7c-bcd9-47e2-8c38-551e7ccdfae6"))
       result.status mustBe (NOT_FOUND)
 
     }
@@ -547,7 +548,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getCompanyBenefits("AA000000A", 2014, "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
+      val result = await(testEmploymentHistoryService.getCompanyBenefits(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
       result.json must be (companyBenefitsJson)
       result.status must be (OK)
     }
@@ -558,7 +559,7 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getCompanyBenefits("AA000000A", 2014, "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
+      val result = await(testEmploymentHistoryService.getCompanyBenefits(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
       result.status must be (NOT_FOUND)
     }
   }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentServiceSpec.scala
@@ -512,16 +512,6 @@ class EmploymentServiceSpec extends PlaySpec with MockitoSugar with TestUtil{
     "get Employment return none" in {
       lazy val paye = loadFile("/json/model/api/paye.json").as[PayAsYouEarn]
 
-      val testEmployment = Json.parse(
-        """| {
-           |      "employmentId": "01318d7c-bcd9-47e2-8c38-551e7ccdfae3",
-           |      "startDate": "2016-01-21",
-           |      "endDate": "2017-01-01",
-           |      "payeReference": "paye-1",
-           |      "employerName": "employer-1"
-           |    }
-        """.stripMargin).as[Employment]
-
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(paye))
 

--- a/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -90,7 +91,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getPayAndTax("AA000000A", 2014, "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
+      val result = await(testEmploymentHistoryService.getPayAndTax(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
       result.json must be(payAndTaxJson)
     }
 
@@ -101,7 +102,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(),Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getPayAndTax("AA000000A", 2014, "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
+      val result = await(testEmploymentHistoryService.getPayAndTax(Nino("AA000000A"), TaxYear(2014), "01318d7c-bcd9-47e2-8c38-551e7ccdfae3"))
       result.status must be(NOT_FOUND)
       result.json must be(payAndTaxJson)
     }

--- a/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
@@ -23,9 +23,9 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.tai.model.rti.RtiData
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
+import uk.gov.hmrc.taxhistory.TaxHistoryException
 import uk.gov.hmrc.taxhistory.model.api.{PayAndTax, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -75,7 +75,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(rtiEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(BAD_REQUEST, HttpResponse(BAD_REQUEST)))))
+        .thenReturn(Future.failed(TaxHistoryException.badRequest))
       val payAsYouEarn = await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))
 
       val payAndTax = payAsYouEarn.payAndTax

--- a/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.tai.model.rti.RtiData
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
+import uk.gov.hmrc.taxhistory.model.nps.NpsEmployment
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -41,7 +42,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
 
   val failureResponseJson = Json.parse("""{"reason":"Bad Request"}""")
 
-  val npsEmploymentResponse =  Json.parse(""" [{
+  val npsEmploymentResponseJson =  Json.parse(""" [{
                                             |    "nino": "AA000000",
                                             |    "sequenceNumber": 1,
                                             |    "worksNumber": "6044041000000",
@@ -56,6 +57,8 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
                                             |    }]
                                           """.stripMargin)
 
+  val npsEmploymentResponse = npsEmploymentResponseJson.as[List[NpsEmployment]]
+
   lazy val iabdsJsonResponse = loadFile("/json/nps/response/iabds.json")
   lazy val rtiEmploymentResponseJson = loadFile("/json/rti/response/dummyRti.json")
   lazy val rtiEmploymentResponse = loadFile("/json/rti/response/dummyRti.json").as[RtiData]
@@ -63,7 +66,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
   "PayAndTax " should {
     "successfully  populated  from rti" in {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(npsEmploymentResponse))))
+        .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(iabdsJsonResponse))))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))

--- a/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/PayAndTaxServiceSpec.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.tai.model.rti.RtiData
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
@@ -56,7 +57,8 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
                                           """.stripMargin)
 
   lazy val iabdsJsonResponse = loadFile("/json/nps/response/iabds.json")
-  lazy val rtiEmploymentResponse = loadFile("/json/rti/response/dummyRti.json")
+  lazy val rtiEmploymentResponseJson = loadFile("/json/rti/response/dummyRti.json")
+  lazy val rtiEmploymentResponse = loadFile("/json/rti/response/dummyRti.json").as[RtiData]
 
   "PayAndTax " should {
     "successfully  populated  from rti" in {
@@ -65,7 +67,7 @@ class PayAndTaxServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(iabdsJsonResponse))))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK,Some(rtiEmploymentResponse))))
+        .thenReturn(Future.successful(rtiEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(BAD_REQUEST)))
       val response =  await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino,TaxYear(2016)))

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -23,6 +23,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
@@ -68,11 +69,10 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(OK, Some(taxAccountJsonResponse))))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(NOT_FOUND)))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, (HttpResponse(NOT_FOUND))))))
 
       val response = await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino, TaxYear(2016)))
 
-      response mustBe a[HttpResponse]
       response.status mustBe OK
       val payAsYouEarn = response.json.as[PayAsYouEarn]
       val taxAccount = payAsYouEarn.taxAccount.get

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -95,7 +95,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(), Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getTaxAccount(testNino.nino, TaxYear.current.previous.startYear))
+      val result = await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear.current.previous))
       result.json must be(taxAccountJson)
     }
 
@@ -106,7 +106,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.getFromCache(Matchers.any(), Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Some(payeJson)))
 
-      val result = await(testEmploymentHistoryService.getTaxAccount(testNino.nino, TaxYear.current.previous.startYear))
+      val result = await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear.current.previous))
       result.status must be(NOT_FOUND)
       result.json must be(taxAccountJson)
     }

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.{PayAsYouEarn, TaxAccount}
-import uk.gov.hmrc.taxhistory.model.nps.{NpsEmployment, NpsTaxAccount}
+import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -68,7 +68,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
+        .thenReturn(Future.failed(TaxHistoryException.notFound(classOf[Iabd], "")))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(taxAccountResponse))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
-import uk.gov.hmrc.taxhistory.model.nps.NpsEmployment
+import uk.gov.hmrc.taxhistory.model.nps.{NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -59,17 +59,17 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
 
   val npsEmploymentResponse = npsEmploymentResponseJson.as[List[NpsEmployment]]
 
-  lazy val taxAccountJsonResponse = loadFile("/json/nps/response/GetTaxAccount.json")
-
+  lazy val taxAccountResponseJson = loadFile("/json/nps/response/GetTaxAccount.json")
+  lazy val taxAccountResponse = taxAccountResponseJson.as[NpsTaxAccount]
 
   "TaxAccount" should {
     "successfully be populated from GetTaxAccount" in {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(NOT_FOUND, None)))
+        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, HttpResponse(NOT_FOUND)))))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(taxAccountJsonResponse))))
+        .thenReturn(Future.successful(taxAccountResponse))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, (HttpResponse(NOT_FOUND))))))
 

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -16,19 +16,18 @@
 
 package uk.gov.hmrc.taxhistory.services
 
-import org.mockito.{Matchers, Mockito}
+import org.mockito.Matchers
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
-import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.{PayAsYouEarn, TaxAccount}
 import uk.gov.hmrc.taxhistory.model.nps.{Iabd, NpsEmployment, NpsTaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
+import uk.gov.hmrc.taxhistory.{GenericHttpError, TaxHistoryException}
 import uk.gov.hmrc.time.TaxYear
 
 import scala.concurrent.Future
@@ -72,7 +71,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(taxAccountResponse))
       when(testEmploymentHistoryService.rtiConnector.getRTIEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.failed(TaxHistoryException(HttpNotOk(NOT_FOUND, (HttpResponse(NOT_FOUND))))))
+        .thenReturn(Future.failed(TaxHistoryException(GenericHttpError(NOT_FOUND, (HttpResponse(NOT_FOUND))))))
 
       val payAsYouEarn = await(testEmploymentHistoryService.retrieveEmploymentsDirectFromSource(testNino, TaxYear(2016)))
 

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -25,6 +25,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.taxhistory.{HttpNotOk, TaxHistoryException}
 import uk.gov.hmrc.taxhistory.model.api.PayAsYouEarn
+import uk.gov.hmrc.taxhistory.model.nps.NpsEmployment
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -40,7 +41,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
 
   val failureResponseJson = Json.parse("""{"reason":"Bad Request"}""")
 
-  val npsEmploymentResponse = Json.parse(
+  val npsEmploymentResponseJson = Json.parse(
     """ [{
       |    "nino": "AA000000",
       |    "sequenceNumber": 12,
@@ -56,6 +57,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       |    }]
     """.stripMargin)
 
+  val npsEmploymentResponse = npsEmploymentResponseJson.as[List[NpsEmployment]]
 
   lazy val taxAccountJsonResponse = loadFile("/json/nps/response/GetTaxAccount.json")
 
@@ -63,7 +65,7 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
   "TaxAccount" should {
     "successfully be populated from GetTaxAccount" in {
       when(testEmploymentHistoryService.npsConnector.getEmployments(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(OK, Some(npsEmploymentResponse))))
+        .thenReturn(Future.successful(npsEmploymentResponse))
       when(testEmploymentHistoryService.npsConnector.getIabds(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND, None)))
       when(testEmploymentHistoryService.npsConnector.getTaxAccount(Matchers.any(), Matchers.any())(Matchers.any[HeaderCarrier]))

--- a/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
@@ -31,13 +31,12 @@ class TaxYearServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
   implicit val hc = HeaderCarrier()
   val testNino = randomNino()
 
-  val testEmploymentHistoryService = TestEmploymentHistoryService.createNew
+  val testEmploymentHistoryService = TestEmploymentHistoryService.createNew()
 
   "get Individual Tax Years " should {
     "successfully return list of four tax years" in {
-      val response = await(testEmploymentHistoryService.getTaxYears(testNino))
-      response.status mustBe OK
-      val taxYears = response.json.as[List[IndividualTaxYear]]
+      val taxYears = await(testEmploymentHistoryService.getTaxYears(testNino))
+
       taxYears.size mustBe 4
 
       val cyMinus1 = TaxYear.current.previous

--- a/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.time.TaxYear
 class TaxYearServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
 
   implicit val hc = HeaderCarrier()
-  val testNino = randomNino().toString()
+  val testNino = randomNino()
 
   val testEmploymentHistoryService = TestEmploymentHistoryService.createNew
 

--- a/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxYearServiceSpec.scala
@@ -20,7 +20,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.taxhistory.model.api.IndividualTaxYear
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear

--- a/test/uk/gov/hmrc/taxhistory/utils/TestEmploymentHistoryService.scala
+++ b/test/uk/gov/hmrc/taxhistory/utils/TestEmploymentHistoryService.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.taxhistory.connectors.nps.NpsConnector
 import uk.gov.hmrc.taxhistory.services.{EmploymentHistoryService, TaxHistoryCacheService}
 
 object TestEmploymentHistoryService extends AnyRef with MockitoSugar {
-  def createNew: EmploymentHistoryService =
+  def createNew(): EmploymentHistoryService =
     new EmploymentHistoryService(
       npsConnector = mock[NpsConnector],
       rtiConnector = mock[RtiConnector],


### PR DESCRIPTION
This large refactor aims to do the following:
- Replace bare 'Ints' and 'Strings' used in method signatures with meaningful domain objects such as `Nino` and `TaxYear`, this should be uncontroversial.
- Make Services and Connectors return domain objects such as `Employment` and `List[CompanyBenefits]` instead of generic HttpResponses and Json. Scala has types so let's take advantage of them! Also, Services should have no cognizance of Json serialisation or Http responses, that should be the job of Controllers and Connectors in my opinion.
- Potentially more controversially, introduce an alternative encoding for errors.

Previously we had a two-layered structure of `Future` and `HttpResponse`, each of which was capable of representing failure. This was used inconsistently and in places there even was a three-layer stack which also used `Either`, or sometimes `Option`... Reasoning with and composing these multi-layered structures was cumbersome (e.g. having to do a map inside a map, or a pattern match inside another pattern match etc...). So, I have decided to flatten all the possible layers into just one, `Future`, which with a bit of boilerplate can now also represent the most common HTTP failures. This enables much better composition in my view. It is a pattern I used in other projects and it has worked well. I'm happy to explain, walk through and debate this if there are any doubts.

Due to the extent of the changes, although all the unit/integration tests work, we should probably run all the acceptance tests again before progressing this anywhere.