### PR TITLE
[AFID-363] View Employment for the full tax year - including 'no data' periods

### DIFF
--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -23,6 +23,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
+import uk.gov.hmrc.time.TaxYear
 
 case class Employment(employmentId: UUID = UUID.randomUUID(),
                       startDate: LocalDate,
@@ -46,11 +47,21 @@ case class Employment(employmentId: UUID = UUID.randomUUID(),
 
 object Employment {
 
-  private val noRecord = "No record"
+  def noRecord(startDate: LocalDate, endDate: Option[LocalDate]): Employment = {
+    val noRecord = "No record"
 
-  def noRecord(startDate: LocalDate, endDate: Option[LocalDate]): Employment =
-    Employment(startDate = startDate, endDate = endDate, payeReference = noRecord, employerName = noRecord,
+    // Override the end date to be None if it represents the end of the current tax year
+    val overriddenEndDate =
+      if (endDate.getOrElse(TaxYear.taxYearFor(startDate).finishes).equals(TaxYear.current.finishes)) {
+        None
+      } else {
+      endDate
+    }
+
+    Employment(startDate = startDate, endDate = overriddenEndDate, payeReference = noRecord, employerName = noRecord,
       employmentStatus = EmploymentStatus.Unknown, worksNumber = noRecord)
+
+  }
 
   implicit val jsonReads: Reads[Employment] = (
     (JsPath \ "employmentId").read[UUID] and

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.json.{JsPath, Reads, Writes}
+import play.api.libs.json.{JsPath, Json, Reads, Writes}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
 
 case class Employment(employmentId: UUID = UUID.randomUUID(),

--- a/app/uk/gov/hmrc/taxhistory/model/api/FillerState.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/FillerState.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.taxhistory.model.api
+
+import uk.gov.hmrc.time.TaxYear
+
+trait FillerState
+
+object FillerState {
+
+  def fillerState(filler: Employment, employment: Employment, taxYear: TaxYear): FillerState =
+    Seq(encompassed(filler, employment, taxYear),
+      overlapCompletely(filler, employment, taxYear),
+      overlapStart(filler, employment, taxYear),
+      overlapEnd(filler, employment, taxYear),
+      Some(Unaffected)).flatten.head
+
+  private def encompassed(filler: Employment, employment: Employment, taxYear: TaxYear): Option[FillerState] =
+    if ((filler.startDate.isEqual(employment.startDate) || filler.startDate.isAfter(employment.startDate)) &&
+      (filler.endDate.getOrElse(taxYear.finishes).equals(employment.endDate.getOrElse(taxYear.finishes)) ||
+        filler.endDate.getOrElse(taxYear.finishes).isBefore(employment.endDate.getOrElse(taxYear.finishes)))) {
+      Some(EncompassedByEmployment)
+    }
+    else {
+      None
+    }
+
+  private def overlapStart(filler: Employment, employment: Employment, taxYear: TaxYear): Option[FillerState] =
+    if (filler.startDate.isBefore(employment.startDate) &&
+      filler.endDate.getOrElse(taxYear.finishes).isAfter(employment.startDate)) {
+      Some(OverlapEmploymentStart)
+    } else {
+      None
+    }
+
+  private def overlapEnd(filler: Employment, employment: Employment, taxYear: TaxYear): Option[FillerState] =
+    if (filler.startDate.isBefore(employment.endDate.getOrElse(taxYear.finishes)) &&
+      filler.endDate.getOrElse(taxYear.finishes).isAfter(employment.endDate.getOrElse(taxYear.finishes))){
+      Some(OverlapEmploymentEnd)
+    } else {
+      None
+    }
+
+  private def overlapCompletely(filler: Employment, employment: Employment, taxYear: TaxYear): Option[FillerState] =
+    if (overlapStart(filler, employment, taxYear).contains(OverlapEmploymentStart) &&
+      overlapEnd(filler, employment, taxYear).contains(OverlapEmploymentEnd)) {
+      Some(OverlapEmployment)
+    } else {
+      None
+    }
+}
+
+case object EncompassedByEmployment extends FillerState
+
+case object OverlapEmploymentStart extends FillerState
+
+case object OverlapEmploymentEnd extends FillerState
+
+case object OverlapEmployment extends FillerState
+
+case object Unaffected extends FillerState
+

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -17,8 +17,6 @@
 package uk.gov.hmrc.taxhistory.services
 
 
-import java.io
-import java.time.LocalDate
 import javax.inject.Inject
 
 import uk.gov.hmrc.domain.Nino

--- a/test/resources/json/withPlaceholders/model/api/paye.json
+++ b/test/resources/json/withPlaceholders/model/api/paye.json
@@ -1,0 +1,132 @@
+{
+  "employments": [
+    {
+      "employmentId": "01318d7c-bcd9-47e2-8c38-551e7ccdfae3",
+      "startDate": "%yearZero%-01-21",
+      "endDate": "%yearZero%-02-21",
+      "payeReference": "paye-1",
+      "employerName": "employer-1",
+      "receivingOccupationalPension": false,
+      "employmentStatus": 1,
+      "worksNumber": "00191048716"
+    },
+    {
+      "employmentId": "019f5fee-d5e4-4f3e-9569-139b8ad81a87",
+      "startDate": "%yearZero%-02-22",
+      "payeReference": "paye-2",
+      "employerName": "employer-2",
+      "receivingOccupationalPension": false,
+      "employmentStatus": 1,
+      "worksNumber": "00191048716"
+    }
+  ],
+  "allowances": [
+    {
+      "allowanceId": "c9923a63-4208-4e03-926d-7c7c88adc7ee",
+      "iabdType": "payeType",
+      "amount": 12
+    }
+  ],
+  "benefits": {
+    "01318d7c-bcd9-47e2-8c38-551e7ccdfae3": [
+      {
+        "companyBenefitId": "c9923a63-4208-4e03-926d-7c7c88adc7ee",
+        "iabdType": "companyBenefitType",
+        "amount": 12
+      }
+    ]
+  },
+  "payAndTax": {
+    "01318d7c-bcd9-47e2-8c38-551e7ccdfae3": {
+      "payAndTaxId": "2e2abe0a-8c4f-49fc-bdd2-cc13054e7172",
+      "taxablePayTotal": 2222.22,
+      "taxTotal": 111.11,
+      "paymentDate": "%yearMinusOne%-02-20",
+      "earlierYearUpdates": []
+    }
+  },
+  "taxAccount": {
+    "taxAccountId": "3923afda-41ee-4226-bda5-e39cc4c82934",
+    "outstandingDebtRestriction": 22.22,
+    "underpaymentAmount": 11.11,
+    "actualPUPCodedInCYPlusOneTaxYear": 33.33
+  },
+  "incomeSources":
+    {
+      "01318d7c-bcd9-47e2-8c38-551e7ccdfae3": {
+        "employmentId": 1,
+        "employmentType": 1,
+        "actualPUPCodedInCYPlusOneTaxYear": 0,
+        "taxCode": "227L",
+        "basisOperation": 2,
+        "employmentTaxDistrictNumber": 126,
+        "employmentPayeRef": "P32",
+        "allowances": [
+          {
+            "npsDescription": "personal allowance",
+            "amount": 11000,
+            "type": 11,
+            "iabdSummaries": [
+              {
+                "amount": 11000,
+                "type": 118,
+                "npsDescription": "Personal Allowance (PA)",
+                "employmentId": null
+              }
+            ],
+            "sourceAmount": 11000
+          }
+        ],
+        "deductions": [
+          {
+            "npsDescription": "employer benefits ",
+            "amount": 65,
+            "type": 7,
+            "iabdSummaries": [
+              {
+                "amount": 65,
+                "type": 28,
+                "npsDescription": "Benefit in Kind",
+                "employmentId": 1
+              },
+              {
+                "amount": 65,
+                "type": 47,
+                "npsDescription": "Other Items",
+                "employmentId": 1
+              }
+            ],
+            "sourceAmount": 65
+          },
+          {
+            "npsDescription": "car benefit",
+            "amount": 8026,
+            "type": 8,
+            "iabdSummaries": [
+              {
+                "amount": 8026,
+                "type": 31,
+                "npsDescription": "Car Benefit",
+                "employmentId": 1
+              }
+            ],
+            "sourceAmount": 8026
+          },
+          {
+            "npsDescription": "medical insurance",
+            "amount": 637,
+            "type": 13,
+            "iabdSummaries": [
+              {
+                "amount": 637,
+                "type": 30,
+                "npsDescription": "Medical Insurance",
+                "employmentId": 1
+              }
+            ],
+            "sourceAmount": 637
+          }
+        ]
+      }
+    }
+}

--- a/test/resources/json/withPlaceholders/model/api/paye.json
+++ b/test/resources/json/withPlaceholders/model/api/paye.json
@@ -2,8 +2,8 @@
   "employments": [
     {
       "employmentId": "01318d7c-bcd9-47e2-8c38-551e7ccdfae3",
-      "startDate": "%yearZero%-01-21",
-      "endDate": "%yearZero%-02-21",
+      "startDate": "%taxYearFinishYear%-01-21",
+      "endDate": "%taxYearFinishYear%-02-21",
       "payeReference": "paye-1",
       "employerName": "employer-1",
       "receivingOccupationalPension": false,
@@ -12,7 +12,7 @@
     },
     {
       "employmentId": "019f5fee-d5e4-4f3e-9569-139b8ad81a87",
-      "startDate": "%yearZero%-02-22",
+      "startDate": "%taxYearFinishYear%-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
       "receivingOccupationalPension": false,
@@ -41,7 +41,7 @@
       "payAndTaxId": "2e2abe0a-8c4f-49fc-bdd2-cc13054e7172",
       "taxablePayTotal": 2222.22,
       "taxTotal": 111.11,
-      "paymentDate": "%yearMinusOne%-02-20",
+      "paymentDate": "%taxYearStartYear%-02-20",
       "earlierYearUpdates": []
     }
   },

--- a/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
+++ b/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
@@ -29,6 +29,9 @@ trait Employments {
   val liveOngoingEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, None, "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
+  val livePotentiallyCeasedEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(30), None, "Nothing", "An Employer",
+    None, None, None, false, EmploymentStatus.Live, testWorksNumber)
+
   val liveStartYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, Some(TaxYear.current.starts.plusDays(10)), "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
@@ -37,7 +40,6 @@ trait Employments {
 
   val liveEndYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.finishes.minusDays(10) , Some(TaxYear.current.finishes), "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
-
 
 
 }

--- a/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
+++ b/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
@@ -29,17 +29,28 @@ trait Employments {
   val liveOngoingEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, None, "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
-  val livePotentiallyCeasedEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(30), None, "Nothing", "An Employer",
+  val liveNoEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(30), None, "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
   val liveStartYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, Some(TaxYear.current.starts.plusDays(10)), "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
-  val liveMidYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(10) , Some(TaxYear.current.finishes.minusDays(10)), "Nothing", "An Employer",
+  val liveMidYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(40) , Some(TaxYear.current.finishes.minusDays(10)), "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
   val liveEndYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.finishes.minusDays(10) , Some(TaxYear.current.finishes), "Nothing", "An Employer",
     None, None, None, false, EmploymentStatus.Live, testWorksNumber)
 
+  val ceasedBeforeStartEmployment = Employment(UUID.randomUUID(), TaxYear.current.previous.starts.plusDays(5) , Some(TaxYear.current.starts.plusDays(30)), "Nothing", "An Employer",
+    None, None, None, false, EmploymentStatus.Ceased, testWorksNumber)
+
+  val ceasedNoEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(90) , None, "Nothing", "An Employer",
+    None, None, None, false, EmploymentStatus.Ceased, testWorksNumber)
+
+  val ceasedAfterEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(60), Some(TaxYear.current.next.starts.plusDays(30)), "Nothing", "An Employer",
+    None, None, None, false, EmploymentStatus.Ceased, testWorksNumber)
+
+  val potentiallyCeasedEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(90) , None, "Nothing", "An Employer",
+    None, None, None, false, EmploymentStatus.PotentiallyCeased, testWorksNumber)
 
 }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -343,12 +343,10 @@ class EmploymentHistoryServiceSpec extends PlaySpec with MockitoSugar with TestU
       onlyInRti must be(empty)
     }
 
-    // todo : look at naming of year placeholders
     "fetch Employments successfully from cache" in {
-
       val taxYear = TaxYear.current.previous
 
-      val placeHolders = Seq(PlaceHolder("%yearMinusOne%", taxYear.startYear.toString), PlaceHolder("%yearZero%", taxYear.finishYear.toString))
+      val placeHolders = Seq(PlaceHolder("%taxYearStartYear%", taxYear.startYear.toString), PlaceHolder("%taxYearFinishYear%", taxYear.finishYear.toString))
       lazy val paye = loadFile("/json/withPlaceholders/model/api/paye.json", placeHolders).as[PayAsYouEarn]
 
       val testEmployment2 =
@@ -477,7 +475,6 @@ class EmploymentHistoryServiceSpec extends PlaySpec with MockitoSugar with TestU
 
     "return a list with no gaps, when potentially ceased employments overlap and have gaps" in {
       val employments = List(ceasedBeforeStartEmployment, liveMidYearEmployment, potentiallyCeasedEmployment)
-      println(s">>>>>> ${testEmploymentHistoryService.addFillers(employments, TaxYear.current)}")
       testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(false, true, false, false))
     }
 
@@ -488,12 +485,12 @@ class EmploymentHistoryServiceSpec extends PlaySpec with MockitoSugar with TestU
 
     "return a list with no gaps, when original employment has a gap at the end" in {
       val employments = List(liveStartYearEmployment, liveMidYearEmployment)
-      testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(false, false, true))
+      testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(false, true, false, true))
     }
 
     "return a list with no gaps, when original employment has a gap at the start and end" in {
       val employments = List(liveMidYearEmployment)
-      testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(true, true, false, true))
+      testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(true, false, true))
     }
   }
 }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.taxhistory.fixtures.Employments
 import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, Employment, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus.Live
 import uk.gov.hmrc.taxhistory.model.nps.{EmploymentStatus, Iabd, NpsEmployment, NpsTaxAccount}
-import uk.gov.hmrc.taxhistory.model.utils.TestUtil
+import uk.gov.hmrc.taxhistory.model.utils.{PlaceHolder, TestUtil}
 import uk.gov.hmrc.taxhistory.services.helpers.EmploymentMatchingHelper
 import uk.gov.hmrc.taxhistory.utils.TestEmploymentHistoryService
 import uk.gov.hmrc.time.TaxYear
@@ -343,31 +343,37 @@ class EmploymentHistoryServiceSpec extends PlaySpec with MockitoSugar with TestU
       onlyInRti must be(empty)
     }
 
+    // todo : look at naming of year placeholders
     "fetch Employments successfully from cache" in {
-      lazy val paye = loadFile("/json/model/api/paye.json").as[PayAsYouEarn]
+      val taxYear = TaxYear.current.previous
+      val yearZero = taxYear.finishYear
+      val yearMinusOne = taxYear.startYear
+
+      val placeHolders = Seq(PlaceHolder("%yearMinusOne%", yearMinusOne.toString), PlaceHolder("%yearZero%", yearZero.toString))
+      lazy val paye = loadFile("/json/withPlaceholders/model/api/paye.json", placeHolders).as[PayAsYouEarn]
 
       val testEmployment2 =
         Employment(UUID.fromString("01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
-          new LocalDate("2016-01-21"), Some(new LocalDate("2017-01-01")), "paye-1", "employer-1",
-          Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
-          Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
-          Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
+          locaDateCyMinus1("01", "21"), Some(locaDateCyMinus1("02", "21")), "paye-1", "employer-1",
+          Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
+          Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
+          Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
           receivingOccupationalPension = false, Live, "00191048716")
 
       val testEmployment3 = Employment(UUID.fromString("019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
-        new LocalDate("2016-02-22"), None, "paye-2", "employer-2",
-        Some("/2014/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/company-benefits"),
-        Some("/2014/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/pay-and-tax"),
-        Some("/2014/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
+        locaDateCyMinus1("02", "22"), None, "paye-2", "employer-2",
+        Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/company-benefits"),
+        Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/pay-and-tax"),
+        Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
         receivingOccupationalPension = false, Live, "00191048716")
 
       // Set up the test data in the cache
-      await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), TaxYear(2014)), paye))
+      await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), taxYear), paye))
 
-      val employments = await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), TaxYear(2014)))
-      employments.head.startDate must be (new LocalDate("2014-04-06"))
-      employments.head.endDate must be (Some(new LocalDate("2016-01-20")))
+      val employments = await(testEmploymentHistoryService.getEmployments(Nino("AA000000A"), taxYear))
       employments.head.employmentStatus must be(EmploymentStatus.Unknown)
+      employments.head.startDate must be (new LocalDate("2016-04-06"))
+      employments.head.endDate must be (Some(new LocalDate("2017-01-20")))
       employments must contain (testEmployment2)
       employments must contain (testEmployment3)
     }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -466,6 +466,13 @@ class EmploymentHistoryServiceSpec extends PlaySpec with MockitoSugar with TestU
       testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(true, false, false))
     }
 
+    "return a list with no gaps, when employments overlap and have gaps at the start" in {
+      val employments = List(livePotentiallyCeasedEmployment, liveMidYearEmployment)
+
+      println(s">>>>>> ${testEmploymentHistoryService.addFillers(employments, TaxYear.current)}")
+      testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(true, false, false))
+    }
+
     "return a list with no gaps, when original employment has a gap in the middle" in {
       val employments = List(liveStartYearEmployment, liveEndYearEmployment)
       testEmploymentHistoryService.addFillers(employments, TaxYear.current) map (isNoRecordEmnployment(_)) must be(Seq(false, true, false))

--- a/test/uk/gov/hmrc/taxhistory/utils/TestUtil.scala
+++ b/test/uk/gov/hmrc/taxhistory/utils/TestUtil.scala
@@ -49,13 +49,10 @@ trait TestUtil {
 
   def locaDateCyMinus1 (mm: String, dd: String): LocalDate = localDateInTaxYear(TaxYear.current.previous, mm, dd)
 
-  // todo : find a better way of checking which year we are in
-  def localDateInTaxYear (taxYear: TaxYear, mm: String, dd: String): LocalDate = {
-    if (s"$dd$mm".toInt < 604) {
-      new LocalDate(s"${taxYear.startYear}-$mm-$dd")
-    } else {
-      new LocalDate(s"${taxYear.finishYear}-$mm-$dd")
-    }
+  private def localDateInTaxYear (taxYear: TaxYear, mm: String, dd: String): LocalDate = {
+    val startYear = new LocalDate(s"${taxYear.startYear}-$mm-$dd")
+    val endYear = new LocalDate(s"${taxYear.finishYear}-$mm-$dd")
+    if (TaxYear.taxYearFor(startYear) == taxYear) startYear else endYear
   }
 
 }


### PR DESCRIPTION
Addressed new requirement to allow overlapping employments as a result of potentially ceased employments.

[AFID-398] Employments and Pensions are not handled chronologically.  Force employments and pensions to be ordered by start date.