### PR TITLE
[ASA-265][JR] Fix for parsing null values from DES NPS Get Tax Account. Lowering log levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,65 @@ Gets tax account information for a given nino and tax year
 | ```:nino```| true | Standard National Insurance Number format e.g. QQ123456A |
 | ```:taxyear```| true | The first year in a tax year. e.g. for tax year 6th April 2016 - 5th April 2017 would be ```2016``` |
 
-**Return Format**
+**Responses**
+
+404 - if there is no tax account information for the nino and tax year
+
+200 - if there is tax account information, the response will contain a json object like:
+
 ```
     TaxAccount {
         taxAccountId :  String UUID Format,,
         outstandingDebtRestriction: Option[BigDecimal],
         underpaymentAmount: Option[BigDecimal],
         actualPUPCodedInCYPlusOneTaxYear: Option[BigDecimal]
+    }
+```
+
+#### Get Income Source
+Gets income source details for a given nino, tax year and employment
+
+| *URL* | *Supported Methods* | *Description* |
+|--------|----|----|
+| ```/:nino/:taxYear/employments/:employmentId/income-source``` | GET | Retrieves the income source for a given nino, tax year and employmentId. |
+
+**Parameters**
+|*Parameter*|*Required*|*Description*|
+|----|----|----|
+| ```:nino```| true | Standard National Insurance Number format e.g. QQ123456A |
+| ```:taxyear```| true | The first year in a tax year. e.g. for tax year 6th April 2016 - 5th April 2017 would be ```2016``` |
+| ```:employmentId```| true | Unique UUID in the standard format e.g. 123e4567-e89b-12d3-a456-426655440000 |
+
+**Responses**
+
+404 - if there is no income source details for the employment
+
+200 - if there is income source details, the response will contain a json object like:
+```
+    IncomeSource{
+        "employmentId": Int,
+        "employmentType": Int,
+        "actualPUPCodedInCYPlusOneTaxYear": Option[BigDecimal],
+        "deductions": [
+            TaDeduction{
+                "type": Int,
+                "npsDescription": String,
+                "amount": BigDecimal,
+                "sourceAmount": Option[BigDecimal]
+            }
+        ],
+        "allowances": [
+            TaAllowance{
+                "type": Int,
+                "npsDescription": String,
+                "amount": BigDecimal,
+                "sourceAmount": Option[BigDecimal],
+            }
+        ],
+        "basisOperation": Option[Int],
+        "employmentTaxDistrictNumber": Int,
+        "employmentPayeRef": String,
+        "taxCode": String
     }
 ```
 
@@ -324,9 +376,23 @@ The logged in user must be either:
       "employmentId" : Int,
       "employmentType" : Int,
       "actualPUPCodedInCYPlusOneTaxYear" : Option[BigDecimal],
-      "deductions" : List[TaDeduction],
-      "allowances" : List[TaAllowance],
-      "taxCode" : uk.gov.hmrc.domain.TaxCode,
+      "deductions" : [
+        TaDeduction{
+          "type": Int,
+          "npsDescription": String,
+          "amount": BigDecimal,
+          "sourceAmount": Option[BigDecimal]
+        }
+      ],
+      "allowances" : [
+        TaAllowance{
+          "type": Int,
+          "npsDescription": String,
+          "amount": BigDecimal,
+          "sourceAmount": Option[BigDecimal]
+        }
+      ],
+      "taxCode" : String,
       "basisOperation" : Option[Int],
       "employmentTaxDistrictNumber" : Int,
       "employmentPayeRef" : String

--- a/app/uk/gov/hmrc/taxhistory/connectors/ConnectorMetrics.scala
+++ b/app/uk/gov/hmrc/taxhistory/connectors/ConnectorMetrics.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.taxhistory.connectors
+
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
+import uk.gov.hmrc.taxhistory.metrics.MetricsEnum.MetricsEnum
+import uk.gov.hmrc.taxhistory.metrics.TaxHistoryMetrics
+import uk.gov.hmrc.taxhistory.utils.Logging
+
+import scala.concurrent.Future
+
+protected trait ConnectorMetrics extends Logging {
+  val metrics: TaxHistoryMetrics
+
+  protected def withMetrics[T](metric: MetricsEnum)(codeBlock: => Future[T])(implicit hc: HeaderCarrier): Future[T] = {
+    val timerContext = metrics.startTimer(metric)
+
+    codeBlock.map{ result =>
+      timerContext.stop()
+      metrics.incrementSuccessCounter(metric)
+      result
+    }.recover {
+      case e : NotFoundException =>
+        timerContext.stop()
+        metrics.incrementSuccessCounter(metric)
+        throw e
+      case e =>
+        metrics.incrementFailedCounter(metric)
+        timerContext.stop()
+        logger.warn(s"Error returned from ${getClass.getSimpleName} connector (${metric.toString}): ${e.toString}: ${e.getMessage}")
+        throw e
+    }
+  }
+}

--- a/app/uk/gov/hmrc/taxhistory/connectors/SquidNpsConnector.scala
+++ b/app/uk/gov/hmrc/taxhistory/connectors/SquidNpsConnector.scala
@@ -20,19 +20,18 @@ import javax.inject.{Inject, Named}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
-import uk.gov.hmrc.taxhistory.metrics.MetricsEnum.MetricsEnum
 import uk.gov.hmrc.taxhistory.metrics.{MetricsEnum, TaxHistoryMetrics}
 import uk.gov.hmrc.taxhistory.model.nps.NpsEmployment
-import uk.gov.hmrc.taxhistory.utils.Logging
 
 import scala.concurrent.Future
 
 class SquidNpsConnector @Inject()(val http: HttpGet,
                                   val metrics: TaxHistoryMetrics,
                                   @Named("nps-hod-base-url") val baseUrl: String,
-                                  @Named("microservice.services.nps-hod.originatorId") val originatorId: String) extends AnyRef with Logging {
+                                  @Named("microservice.services.nps-hod.originatorId") val originatorId: String) extends ConnectorMetrics {
 
   private val servicePrefix = "nps-hod-service/services/nps"
+
   def employmentUrl(nino: Nino, year: Int) = s"$baseUrl/$servicePrefix/person/${nino.value}/employment/$year"
 
   def basicNpsHeaders(hc: HeaderCarrier): HeaderCarrier = {
@@ -45,29 +44,5 @@ class SquidNpsConnector @Inject()(val http: HttpGet,
     withMetrics(MetricsEnum.NPS_GET_EMPLOYMENTS) {
       http.GET[List[NpsEmployment]](employmentUrl(nino, year))
     }
-  }
-
-  private def withMetrics[T](metric: MetricsEnum)(codeBlock: => Future[T])(implicit hc: HeaderCarrier) = {
-    val timerContext = metrics.startTimer(metric)
-
-    val result: Future[T] = codeBlock
-
-    result.onSuccess{
-      case _ =>
-        timerContext.stop()
-        metrics.incrementSuccessCounter(metric)
-    }
-
-    result.onFailure{
-      case _ : NotFoundException  =>
-        timerContext.stop()
-        metrics.incrementSuccessCounter(metric)
-      case e =>
-        metrics.incrementFailedCounter(metric)
-        timerContext.stop()
-        logger.warn(s"SQUID NPS connector - Error returned from SQUID NPS connector (${metric.toString}): ${e.toString}: ${e.getMessage}")
-    }
-
-    result
   }
 }

--- a/app/uk/gov/hmrc/taxhistory/controllers/TaxHistoryController.scala
+++ b/app/uk/gov/hmrc/taxhistory/controllers/TaxHistoryController.scala
@@ -31,7 +31,7 @@ trait TaxHistoryController extends BaseController with Logging {
         logger.warn("Bad Request: " + e400.message)
         BadRequest
       case e404: NotFoundException =>
-        logger.warn("404 Not found: " + e404.message)
+        logger.info("404 Not found: " + e404.message)
         NotFound
       case e4xx: Upstream4xxResponse =>
         logger.warn(s"Service returned error ${e4xx.upstreamResponseCode}: ${e4xx.message}")

--- a/app/uk/gov/hmrc/taxhistory/model/api/IncomeSource.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/IncomeSource.scala
@@ -17,17 +17,18 @@
 package uk.gov.hmrc.taxhistory.model.api
 
 import play.api.libs.json.Json
-import uk.gov.hmrc.taxhistory.model.nps.StatePension
+import uk.gov.hmrc.taxhistory.model.nps.{TaAllowance, TaDeduction}
 
+case class IncomeSource(employmentId: Int,
+                        employmentType: Int,
+                        actualPUPCodedInCYPlusOneTaxYear: Option[BigDecimal],
+                        deductions: List[TaDeduction],
+                        allowances: List[TaAllowance],
+                        taxCode: String,
+                        basisOperation: Option[Int],
+                        employmentTaxDistrictNumber: Int,
+                        employmentPayeRef: String)
 
-case class PayAsYouEarn(employments: List[Employment] = Nil,
-                        allowances: List[Allowance] = Nil,
-                        incomeSources: Map[String, IncomeSource] = Map.empty,
-                        benefits: Map[String, List[CompanyBenefit]] = Map.empty,
-                        payAndTax: Map[String, PayAndTax] = Map.empty,
-                        taxAccount: Option[TaxAccount] = None,
-                        statePension: Option[StatePension] = None)
-
-object PayAsYouEarn {
-  implicit val formats = Json.format[PayAsYouEarn]
+object IncomeSource {
+  implicit val formats = Json.format[IncomeSource]
 }

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -131,7 +131,7 @@ class EmploymentHistoryService @Inject()(val desNpsConnector: DesNpsConnector,
         }
       }
     } else {
-      Future(None)
+      Future.failed(new NotFoundException(s"TaxAccount only available for last completed tax year"))
     }
   }
 
@@ -149,11 +149,11 @@ class EmploymentHistoryService @Inject()(val desNpsConnector: DesNpsConnector,
   }
 
   def getIncomeSource(nino: Nino, taxYear: TaxYear, employmentId: String)(implicit headerCarrier: HeaderCarrier): Future[Option[IncomeSource]] = {
-    if (taxYear == TaxYear.current) {
+    (if (taxYear == TaxYear.current) {
       getFromCache(nino, taxYear).map(_.incomeSources.get(employmentId))
     } else {
       Future(None)
-    }
+    }).orNotFound(s"IncomeSource not found for NINO ${nino.value}, tax year ${taxYear.toString}, and employmentId $employmentId")
   }
 
   def getTaxYears(nino: Nino): Future[List[IndividualTaxYear]] = {

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -238,12 +238,12 @@ class EmploymentHistoryService @Inject()(val desNpsConnector: DesNpsConnector,
     // One [[PayAsYouEarn]] instance will be produced for each npsEmployment.
     val payes: List[PayAsYouEarn] = npsEmployments.map { npsEmployment =>
 
-      val incomeSource = if (taxAccountOption.isDefined) taxAccountOption.get.matchedIncomeSource(npsEmployment) else None
+      val matchedIncomeSource = taxAccountOption.flatMap(_.matchedIncomeSource(npsEmployment))
 
       EmploymentHistoryServiceHelper.buildPAYE(
         rtiEmployment = employmentMatches.get(npsEmployment),
         iabds = iabdsNoStatePensions.matchedCompanyBenefits(npsEmployment),
-        incomeSource = incomeSource,
+        incomeSource = matchedIncomeSource,
         npsEmployment = npsEmployment
       )
     }

--- a/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/EmploymentHistoryService.scala
@@ -239,6 +239,10 @@ class EmploymentHistoryService @Inject()(val desNpsConnector: DesNpsConnector,
     val payes: List[PayAsYouEarn] = npsEmployments.map { npsEmployment =>
 
       val matchedIncomeSource = taxAccountOption.flatMap(_.matchedIncomeSource(npsEmployment))
+      
+      if(matchedIncomeSource.isEmpty && taxYear == TaxYear.current) {
+        logger.warn("No matched income source found for employment in current tax year")
+      }
 
       EmploymentHistoryServiceHelper.buildPAYE(
         rtiEmployment = employmentMatches.get(npsEmployment),

--- a/app/uk/gov/hmrc/taxhistory/services/helpers/EmploymentHistoryServiceHelper.scala
+++ b/app/uk/gov/hmrc/taxhistory/services/helpers/EmploymentHistoryServiceHelper.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.taxhistory.services.helpers
 
 import uk.gov.hmrc.tai.model.rti.RtiEmployment
-import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, PayAndTax, PayAsYouEarn}
-import uk.gov.hmrc.taxhistory.model.nps._
+import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, IncomeSource, PayAndTax, PayAsYouEarn}
+import uk.gov.hmrc.taxhistory.model.nps.{NpsEmployment, Iabd}
 import uk.gov.hmrc.taxhistory.services.helpers.IabdsOps._
 import uk.gov.hmrc.taxhistory.utils.Logging
 

--- a/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/TaxAccountControllerSpec.scala
@@ -27,11 +27,10 @@ import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
-import uk.gov.hmrc.domain.{Nino, TaxCode}
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.taxhistory.model.api.TaxAccount
-import uk.gov.hmrc.taxhistory.model.nps.IncomeSource
+import uk.gov.hmrc.taxhistory.model.api.{IncomeSource, TaxAccount}
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 import uk.gov.hmrc.taxhistory.services.EmploymentHistoryService
 import uk.gov.hmrc.taxhistory.utils.{HttpErrors, TestRelationshipAuthService}
@@ -48,7 +47,7 @@ class TaxAccountControllerSpec extends UnitSpec with OneServerPerSuite with Mock
 
   private val testTaxAccount = TaxAccount()
   private val testTaxYear = TaxYear.current.previous.currentYear
-  private val testTaxCode = TaxCode("1150L")
+  private val testTaxCode = "1150L"
 
   override def beforeEach: Unit = {
     reset(mockEmploymentHistoryService)

--- a/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
@@ -22,7 +22,6 @@ import org.joda.time.LocalDate
 import play.api.libs.json.JsObject
 import play.api.libs.json._
 import play.api.libs.json.Json._
-import uk.gov.hmrc.domain.TaxCode
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.taxhistory.model.nps._
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
@@ -235,7 +234,7 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
         employmentId = 1,
         employmentType = 1,
         actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal("0")),
-        taxCode = TaxCode("227L"),
+        taxCode = "227L",
         basisOperation = Some(2),
         employmentTaxDistrictNumber = 126,
         employmentPayeRef = "P32",

--- a/test/uk/gov/hmrc/taxhistory/model/nps/NpsTaxAccountSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/nps/NpsTaxAccountSpec.scala
@@ -17,8 +17,11 @@
 package uk.gov.hmrc.taxhistory.model.nps
 
 import org.joda.time.LocalDate
-import play.api.libs.json.JsValue
+import play.api.libs.json._
+import play.api.libs.json.Json.fromJson
+import uk.gov.hmrc.domain.TaxCode
 import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.taxhistory.model.api.IncomeSource
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus.Live
 import uk.gov.hmrc.taxhistory.model.utils.TestUtil
 
@@ -31,34 +34,300 @@ class NpsTaxAccountSpec extends TestUtil with UnitSpec {
   private val outStandingDebt = 145.75
   private val underPayment = 15423.29
 
-  private val taxAccount = getTaxAcoountResponseURLDummy.as[NpsTaxAccount]
+  private val taxAccount = getTaxAcoountResponseURLDummy.as[NpsTaxAccount](NpsTaxAccount.formats)
 
-  "GetTaxAccount" should {
-    "transform Nps Get Tax Account Response Json correctly to NpsTaxAccount Model " in {
+  private val testNpsEmployment = NpsEmployment(
+    nino = "AA000000",
+    sequenceNumber = 6,
+    taxDistrictNumber = "961",
+    payeNumber = "AZ00010",
+    employerName = "Aldi",
+    worksNumber = Some("6044041000000"),
+    receivingJobSeekersAllowance = false,
+    otherIncomeSourceIndicator = false,
+    startDate = new LocalDate("2015-01-21"),
+    endDate = None,
+    receivingOccupationalPension = false,
+    employmentStatus = Live
+  )
+
+  private val testDeductions = List(
+    TaDeduction(`type` = 32, npsDescription = "savings income taxable at higher rate", amount = BigDecimal("38625"), sourceAmount = Some(0))
+  )
+  private val testAllowances = List(
+    TaAllowance(`type` = 11, npsDescription = "personal allowance", amount = BigDecimal("11500"), sourceAmount = Some(11500))
+  )
+  private val testNpsIncomeSource = NpsIncomeSource(
+    employmentId = 6,
+    employmentTaxDistrictNumber = Some(961),
+    employmentPayeRef = Some("AZ00010"),
+    actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal(3.14)),
+    deductions = testDeductions,
+    allowances = testAllowances,
+    employmentType = Some(23),
+    taxCode = Some("TAX1234"),
+    basisOperation = Some(64)
+  )
+
+  "NpsTaxAccount" when {
+    "transforming NPS Get Tax Account API response Json correctly to NpsTaxAccount Model " in {
       taxAccount shouldBe a[NpsTaxAccount]
       taxAccount.getPrimaryEmploymentId shouldBe Some(primaryEmploymentId)
       taxAccount.getActualPupCodedInCYPlusOne shouldBe Some(actualPupCodedInCYPlusOne)
       taxAccount.getOutStandingDebt shouldBe Some(outStandingDebt)
       taxAccount.getUnderPayment shouldBe Some(underPayment)
     }
-  }
 
-  "matchedIncomeSource" should {
-    "return None when no emnployment and income source match" in {
-      val npsEmployment = NpsEmployment(
-        "AA000000", 6, "999", "AZ00010", "Aldi", Some("6044041000000"), receivingJobSeekersAllowance = false,
-        otherIncomeSourceIndicator = false, new LocalDate("2015-01-21"), None, receivingOccupationalPension = false, Live)
+    "deserialising the 'incomeSources' field" should {
+      val incomeSource1Deserialised = NpsIncomeSource(
+        employmentId = 12,
+        employmentType = Some(1),
+        actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal("240")),
+        deductions = testDeductions,
+        allowances = testAllowances,
+        taxCode = Some("K7757"),
+        basisOperation = None,
+        employmentTaxDistrictNumber = Some(961),
+        employmentPayeRef = Some("AZ00010")
+      )
+      val incomeSourcesDeserialised = List(incomeSource1Deserialised)
 
-      taxAccount.matchedIncomeSource(npsEmployment) shouldBe None
+      val incomeSourcesSerialised = Json.parse(
+        s"""
+           | [
+           |   {
+           |     "employmentId":12,
+           |     "employmentType":1,
+           |     "actualPUPCodedInCYPlusOneTaxYear":240,
+           |     "deductions":[
+           |       {"type":32,"npsDescription":"savings income taxable at higher rate","amount":38625,"sourceAmount":0}
+           |     ],
+           |     "allowances":[
+           |       {"type":11,"npsDescription":"personal allowance","amount":11500,"sourceAmount":11500}
+           |     ],
+           |     "taxCode":"K7757",
+           |     "employmentTaxDistrictNumber":961,
+           |     "employmentPayeRef":"AZ00010"
+           |   }
+           | ]
+        """.stripMargin)
+
+      "deserialise from an empty json array" in {
+        val jsonIncomeSourcesMissing = getTaxAcoountResponseURLDummy.as[JsObject] + ("incomeSources" -> JsArray())
+        fromJson[NpsTaxAccount](jsonIncomeSourcesMissing).get.incomeSources shouldBe empty
+      }
+
+      "deserialise from a non-empty json array of allowances" in {
+        val jsonIncomeSourcesPresent = getTaxAcoountResponseURLDummy.as[JsObject] + ("incomeSources" -> incomeSourcesSerialised)
+        fromJson[NpsTaxAccount](jsonIncomeSourcesPresent).get.incomeSources shouldBe incomeSourcesDeserialised
+      }
+
+      "deserialise when 'employmentType' contains a null value (ASA-265)" in {
+        val noEmploymentTypeJson = (incomeSourcesSerialised \ 0).as[JsObject] + ("employmentType" -> JsNull)
+        fromJson[NpsIncomeSource](noEmploymentTypeJson).get.employmentType shouldBe None
+      }
+
+      "deserialise when 'employmentTaxDistrictNumber' contains a null value (ASA-265)" in {
+        val noEmplTaxDistrictNumJson = (incomeSourcesSerialised \ 0).as[JsObject] + ("employmentTaxDistrictNumber" -> JsNull)
+        fromJson[NpsIncomeSource](noEmplTaxDistrictNumJson).get.employmentTaxDistrictNumber shouldBe None
+      }
+
+      "deserialise when 'employmentPayeRef' contains a null value (ASA-265)" in {
+        val noEmploymentPayeRefJson = (incomeSourcesSerialised \ 0).as[JsObject] + ("employmentPayeRef" -> JsNull)
+        fromJson[NpsIncomeSource](noEmploymentPayeRefJson).get.employmentPayeRef shouldBe None
+      }
+      "deserialise when 'taxCode' contains a null value (ASA-265)" in {
+        val noTaxCodeJson = (incomeSourcesSerialised \ 0).as[JsObject] + ("taxCode" -> JsNull)
+        fromJson[NpsIncomeSource](noTaxCodeJson).get.taxCode shouldBe None
+      }
+
+      "deserialise when 'taxCode' contains a value that is not valid for the TaxCode domain class (ASA-265)" in {
+        val unusualTaxCode = "FNORDS"
+        assertThrows[IllegalArgumentException] {
+          TaxCode(unusualTaxCode)
+        }
+        val withUnusualTaxCodeJson = (incomeSourcesSerialised \ 0).as[JsObject] + ("taxCode" -> JsString(unusualTaxCode))
+        val jsResult = fromJson[NpsIncomeSource](withUnusualTaxCodeJson)
+        jsResult shouldBe a[JsSuccess[_]]
+        jsResult.get.taxCode shouldBe Some(unusualTaxCode)
+      }
     }
 
-    "return a single income source when income sources matche the employment" in {
-      val targetEmploymentId = 6
-      val npsEmployment = NpsEmployment(
-        "AA000000", targetEmploymentId, "961", "AZ00010", "Aldi", Some("6044041000000"), receivingJobSeekersAllowance = false,
-        otherIncomeSourceIndicator = false, new LocalDate("2015-01-21"), None, receivingOccupationalPension = false, Live)
+    "matchedIncomeSource is called" should {
+      "return None when no employment and income source match" in {
+        val npsEmployment = NpsEmployment(
+          "AA000000", 6, "999", "AZ00010", "Aldi", Some("6044041000000"), receivingJobSeekersAllowance = false,
+          otherIncomeSourceIndicator = false, new LocalDate("2015-01-21"), None, receivingOccupationalPension = false, Live)
 
-      taxAccount.matchedIncomeSource(npsEmployment).get.employmentId shouldBe targetEmploymentId
+        taxAccount.matchedIncomeSource(npsEmployment) shouldBe None
+      }
+
+      "return a single income source when income sources match the employment" in {
+        val targetEmploymentId = 6
+        val npsEmployment = NpsEmployment(
+          "AA000000", targetEmploymentId, "961", "AZ00010", "Aldi", Some("6044041000000"), receivingJobSeekersAllowance = false,
+          otherIncomeSourceIndicator = false, new LocalDate("2015-01-21"), None, receivingOccupationalPension = false, Live)
+
+        taxAccount.matchedIncomeSource(npsEmployment).get.employmentId shouldBe targetEmploymentId
+      }
+
+      "return None if the income source's would normally match the employment but the employmentTaxDistrictNumber or employmentPayeRef is not present (ASA-265)" in {
+        val targetEmploymentId = 6
+        val matchingTaxDistrictNum = 961
+        val matchingEmploymentRef = "AZ00010"
+        val npsEmployment = testNpsEmployment.copy(
+          sequenceNumber = targetEmploymentId,
+          taxDistrictNumber = matchingTaxDistrictNum.toString,
+          payeNumber = matchingEmploymentRef
+        )
+
+        val incomeSource = testNpsIncomeSource.copy(
+          employmentId = targetEmploymentId,
+          employmentTaxDistrictNumber = Some(matchingTaxDistrictNum),
+          employmentPayeRef = Some(matchingEmploymentRef)
+        )
+
+        NpsTaxAccount(List(
+          incomeSource
+        )).matchedIncomeSource(npsEmployment).get.employmentId shouldBe targetEmploymentId
+
+        NpsTaxAccount(List(
+          incomeSource.copy(employmentTaxDistrictNumber = None)
+        )).matchedIncomeSource(npsEmployment) shouldBe None
+
+        NpsTaxAccount(List(
+          incomeSource.copy(employmentPayeRef = None)
+        )).matchedIncomeSource(npsEmployment) shouldBe None
+      }
+    }
+
+    "getPrimaryEmploymentId is called" should {
+      "return the employmentId if there is an income source whose employmentType indicates a primary income " in {
+        val employmentTypePrimaryIncome = 1
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypePrimaryIncome)
+        ))).getPrimaryEmploymentId shouldBe Some(testNpsIncomeSource.employmentId)
+      }
+
+      "return None if there is no income source whose employmentType indicates a primary income" in {
+        val employmentTypeNotPrimary = 2
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypeNotPrimary)
+        ))).getPrimaryEmploymentId shouldBe None
+      }
+
+      "work with missing employmentType (ASA-265)" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = None
+        ))).getPrimaryEmploymentId shouldBe None
+      }
+    }
+
+    "getOutStandingDebt is called" should {
+      val employmentTypePrimaryIncome = 1
+      val deductionTypeOutstandingDebt = 41
+      val deductionWithOutstandingDebt = TaDeduction(
+        `type` = deductionTypeOutstandingDebt,
+        npsDescription = "desc",
+        amount = BigDecimal("123"),
+        sourceAmount = Some(BigDecimal("456"))
+      )
+
+      "return the sourceAmount from a primary income with a deduction indicating outstanding debt" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypePrimaryIncome),
+          deductions = List(deductionWithOutstandingDebt)
+        ))).getOutStandingDebt shouldBe deductionWithOutstandingDebt.sourceAmount
+      }
+
+      "work with missing employmentType (ASA-265)" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = None,
+          deductions = List(deductionWithOutstandingDebt)
+        ))).getOutStandingDebt shouldBe None
+      }
+    }
+
+    "getUnderPayment is called" should {
+      val employmentTypePrimaryIncome = 1
+      val deductionTypeUnderpaymentAmount = 35
+      val deductionWithUnderpayment = TaDeduction(
+        `type` = deductionTypeUnderpaymentAmount,
+        npsDescription = "desc",
+        amount = BigDecimal("123"),
+        sourceAmount = Some(BigDecimal("456"))
+      )
+
+      "return the sourceAmount from a primary income with a deduction indicating an underpayment amount" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypePrimaryIncome),
+          deductions = List(deductionWithUnderpayment)
+        ))).getUnderPayment shouldBe deductionWithUnderpayment.sourceAmount
+      }
+
+      "work with missing employmentType (ASA-265)" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = None,
+          deductions = List(deductionWithUnderpayment)
+        ))).getUnderPayment shouldBe None
+      }
+    }
+
+    "getActualPupCodedInCYPlusOne is called" should {
+      val employmentTypePrimaryIncome = 1
+      val employmentTypeNotPrimaryIncome = 2
+      "return getActualPupCodedInCYPlusOne if there is an income source with an employmentType indicating primary income" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypePrimaryIncome),
+          actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal("123"))
+        ))).getActualPupCodedInCYPlusOne shouldBe Some(BigDecimal("123"))
+      }
+
+      "return None if there is no income source with an employmentType indicating primary income" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = Some(employmentTypeNotPrimaryIncome),
+          actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal("123"))
+        ))).getActualPupCodedInCYPlusOne shouldBe None
+      }
+
+      "return None if employmentType is missing (ASA-265)" in {
+        NpsTaxAccount(List(testNpsIncomeSource.copy(
+          employmentType = None,
+          actualPUPCodedInCYPlusOneTaxYear = Some(BigDecimal("123"))
+        ))).getActualPupCodedInCYPlusOne shouldBe None
+      }
+    }
+  }
+
+  "NpsIncomeSource" when {
+    "toTaxAccount is called" should {
+      "return IncomeSource if taxCode, employmentType, employmentTaxDistrictNumber, and employmentPayeRef are present" in {
+        testNpsIncomeSource.toIncomeSource shouldBe Some(
+          IncomeSource(
+            employmentId = testNpsIncomeSource.employmentId,
+            employmentTaxDistrictNumber = testNpsIncomeSource.employmentTaxDistrictNumber.get,
+            employmentPayeRef = testNpsIncomeSource.employmentPayeRef.get,
+            actualPUPCodedInCYPlusOneTaxYear = testNpsIncomeSource.actualPUPCodedInCYPlusOneTaxYear,
+            deductions = testNpsIncomeSource.deductions,
+            allowances = testNpsIncomeSource.allowances,
+            employmentType = testNpsIncomeSource.employmentType.get,
+            taxCode = testNpsIncomeSource.taxCode.get,
+            basisOperation = testNpsIncomeSource.basisOperation
+          )
+        )
+      }
+      "return None if there is no taxCode" in {
+        testNpsIncomeSource.copy(taxCode = None).toIncomeSource shouldBe None
+      }
+      "return None if there is no employmentType" in {
+        testNpsIncomeSource.copy(employmentType = None).toIncomeSource shouldBe None
+      }
+      "return None if there is no employmentTaxDistrictNumber" in {
+        testNpsIncomeSource.copy(employmentTaxDistrictNumber = None).toIncomeSource shouldBe None
+      }
+      "return None if there is no employmentPayeRef" in {
+        testNpsIncomeSource.copy(employmentPayeRef = None).toIncomeSource shouldBe None
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -269,8 +269,10 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
       await(testEmploymentHistoryService.retrieveNpsIabds(testNino, TaxYear(2016))) shouldBe List.empty
     }
 
-    "return none where tax year is not cy-1" in {
-      await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear(2015))) shouldBe None
+    "return 404 Not Found for tax account details when" in {
+      intercept[NotFoundException]{
+        await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear(2015)))
+      }
     }
 
     "return None from get Nps Tax Account api for bad request response " in {

--- a/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/TaxAccountServiceSpec.scala
@@ -78,9 +78,10 @@ class TaxAccountServiceSpec extends PlaySpec with MockitoSugar with TestUtil {
       taxAccount must be(testTaxAccount)
     }
 
-    "return no tax account from cache for current year" in {
-      val taxAccount = await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear.current))
-      taxAccount must be(None)
+    "fail to retrieve from cache for current year with NotFoundException" in {
+      intercept[NotFoundException] {
+        await(testEmploymentHistoryService.getTaxAccount(testNino, TaxYear.current))
+      }
     }
 
   }

--- a/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
@@ -34,11 +34,11 @@ class EmploymentHistoryServiceHelperSpec extends PlaySpec with MockitoSugar with
       "AA000000", 6, "0531", "J4816", "Aldi", Some("6044041000000"), receivingJobSeekersAllowance = false,
       otherIncomeSourceIndicator = false, new LocalDate("2015-01-21"), None, receivingOccupationalPension = false, Live))
 
-  val testTaxCode = TaxCode("1150L")
+  val testTaxCode = "1150L"
   lazy val testRtiData: RtiData = loadFile("/json/rti/response/dummyRti.json").as[RtiData]
   lazy val testIabds: List[Iabd] = loadFile("/json/nps/response/iabds.json").as[List[Iabd]]
+
   lazy val testIncomeSource = IncomeSource(1, 1, None, Nil, Nil, testTaxCode, None, 1, "")
-  lazy val testNpsTaxAccount: NpsTaxAccount = loadFile("/json/nps/response/GetTaxAccount.json").as[NpsTaxAccount]
 
   val startDate = new LocalDate("2015-01-21")
   lazy val employment1 = Employment(payeReference = "1234",


### PR DESCRIPTION
Changes include:

- Connectors now treat a 404 response as a success metric rather than a failure metric, and log level lowered from WARN to INFO.

- The income source and tax account endpoints now return 404 rather than a literal null if there's no data. 

- Updated README for changed endpoints. Also added in missing endpoints.

- Fixing two bugs during parsing of the income sources from the DES NPS Get Tax Account API response. One bug where taxCode may not be in a format that the TaxCode domain class allows. One other bug where the taxCode, employmentType, employmentTaxDistrictNumber, and employmentPayeRef could be null.

- Logging warning when no income-source could be matched for an employment (current tax year only).