### PR TITLE
[ASA-281][JR,RV] Introduce an 'employmentPaymentType' field on employments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,19 @@ Gets a list of employment objects for a given nino and tax year
     companyBenefitsURI: Option[String] (e.g. /:taxyear/employments/:employmentId/company-benefits),
     payAndTaxURI: Option[String] (e.g. /:taxyear/employments/:employmentId/pay-and-tax),
     employmentURI: Option[String] (e.g. /:taxyear/employments/:employmentId),
-    receivingOccupationalPension:Boolean,
-    receivingJobSeekersAllowance:Boolean,
+    employmentPaymentType: Option[String] (see note below),
     employmentStatus: Int (Live=1, PotentiallyCeased=2, Ceased=3, Unknown=99),
     worksNumber:String
   }
 ]
 ```
+
+The `employmentPaymentType` field, if present, will have one of the following values:
+- "OccupationalPension"
+- "JobseekersAllowance"
+- "IncapacityBenefit"
+- "EmploymentAndSupportAllowance"
+- "StatePensionLumpSum"
 
 #### Get individual Employment
 Gets an employment object for a given nino and tax year and employmentId
@@ -82,12 +88,18 @@ Employment{
   companyBenefitsURI: Option[String] (e.g. /:taxyear/employments/:employmentId/company-benefits),
   payAndTaxURI: Option[String] (e.g. /:taxyear/employments/:employmentId/pay-and-tax),
   employmentURI: Option[String] (e.g. /:taxyear/employments/:employmentId),
-  receivingOccupationalPension:Boolean,
-  receivingJobSeekersAllowance:Boolean,
+  employmentPaymentType: Option[String] (see note below),
   employmentStatus: Int (Live=1, PotentiallyCeased=2, Ceased=3, Unknown=99),
   worksNumber:String
 }
 ```
+
+The `employmentPaymentType` field, if present, will have one of the following values:
+- "OccupationalPension"
+- "JobseekersAllowance"
+- "IncapacityBenefit"
+- "EmploymentAndSupportAllowance"
+- "StatePensionLumpSum"
 
 #### Get List of Allowances
 Gets a list of allowance objects for a given nino and tax year
@@ -326,8 +338,7 @@ The logged in user must be either:
       "endDate" : Option[LocalDate],
       "payeReference" : String,
       "employerName" : String,
-      "receivingOccupationalPension" : Boolean,
-      "receivingJobSeekersAllowance" : Boolean,
+      "employmentPaymentType" : Option[String] (see note below),
       "employmentStatus" : Int (Live=1, PotentiallyCeased=2, Ceased=3, Unknown=99),
       "worksNumber" : String,
       "companyBenefitsURI" : Option[String],
@@ -423,3 +434,10 @@ Empty list, empty map and optional handling:
 - For the lists (`employments`, `allowances`), if there are no list elements, the key will still be present in the json but with an empty list value, e.g. `"allowances" : []`
 - For the maps (`benefits`, `payAndTax`, `incomeSources`), if there are no employments with any details, the map's key will still be present but the map's object value would be an empty object, e.g. `"benefits" : {}`.
 - For the optionals (`taxAccount`, `statePension`), if they are not available then the key/value entry will be missing from the json.
+
+The `employmentPaymentType` field, if present, will have one of the following values:
+- "OccupationalPension"
+- "JobseekersAllowance"
+- "IncapacityBenefit"
+- "EmploymentAndSupportAllowance"
+- "StatePensionLumpSum"

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -23,6 +23,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
+import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType._
 import uk.gov.hmrc.time.TaxYear
 
 case class Employment(employmentId: UUID = UUID.randomUUID(),
@@ -35,6 +36,7 @@ case class Employment(employmentId: UUID = UUID.randomUUID(),
                       employmentURI: Option[String] = None,
                       receivingOccupationalPension: Boolean = false,
                       receivingJobSeekersAllowance: Boolean = false,
+                      employmentPaymentType: Option[EmploymentPaymentType] = None,
                       employmentStatus: EmploymentStatus,
                       worksNumber: String) {
 
@@ -60,7 +62,7 @@ object Employment {
     }
 
     Employment(startDate = startDate, endDate = overriddenEndDate, payeReference = noRecord, employerName = noRecord,
-      employmentStatus = EmploymentStatus.Unknown, worksNumber = noRecord)
+      employmentStatus = EmploymentStatus.Unknown,  worksNumber = noRecord)
 
   }
 
@@ -76,6 +78,7 @@ object Employment {
       (JsPath \ "receivingOccupationalPension").read[Boolean] and
       (JsPath \ "receivingJobSeekersAllowance").read[Boolean] and
       JsPath.read[EmploymentStatus] and
+      (JsPath \ "employmentPaymentType").readNullable[EmploymentPaymentType] and
       (JsPath \ "worksNumber").read[String]
     ) (Employment.apply _)
 
@@ -91,6 +94,7 @@ object Employment {
       (JsPath \ "employmentURI").writeNullable[String] and
       (JsPath \ "receivingOccupationalPension").write[Boolean] and
       (JsPath \ "receivingJobSeekersAllowance").write[Boolean] and
+      (JsPath \ "employmentPaymentType").writeNullable[EmploymentPaymentType] and
       JsPath.write[EmploymentStatus] and
       (JsPath \ "worksNumber").write[String]
     ) (unlift(Employment.unapply))

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.json.{JsPath, Json, Reads, Writes}
+import play.api.libs.json.{__, Json, Reads, Writes}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus
 import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType._
 import uk.gov.hmrc.time.TaxYear
@@ -34,11 +34,12 @@ case class Employment(employmentId: UUID = UUID.randomUUID(),
                       companyBenefitsURI: Option[String] = None,
                       payAndTaxURI: Option[String] = None,
                       employmentURI: Option[String] = None,
-                      receivingOccupationalPension: Boolean = false,
-                      receivingJobSeekersAllowance: Boolean = false,
                       employmentPaymentType: Option[EmploymentPaymentType] = None,
                       employmentStatus: EmploymentStatus,
                       worksNumber: String) {
+
+  def isOccupationalPension: Boolean = employmentPaymentType.contains(OccupationalPension)
+  def isJobseekersAllowance: Boolean = employmentPaymentType.contains(JobseekersAllowance)
 
   def enrichWithURIs(taxYear: Int): Employment = {
     val baseURI = s"/$taxYear/employments/${employmentId.toString}"
@@ -67,36 +68,32 @@ object Employment {
   }
 
   implicit val jsonReads: Reads[Employment] = (
-    (JsPath \ "employmentId").read[UUID] and
-      (JsPath \ "startDate").read[LocalDate] and
-      (JsPath \ "endDate").readNullable[LocalDate] and
-      (JsPath \ "payeReference").read[String] and
-      (JsPath \ "employerName").read[String] and
-      (JsPath \ "companyBenefitsURI").readNullable[String] and
-      (JsPath \ "payAndTaxURI").readNullable[String] and
-      (JsPath \ "employmentURI").readNullable[String] and
-      (JsPath \ "receivingOccupationalPension").read[Boolean] and
-      (JsPath \ "receivingJobSeekersAllowance").read[Boolean] and
-      (JsPath \ "employmentPaymentType").readNullable[EmploymentPaymentType] and
-      JsPath.read[EmploymentStatus] and
-      (JsPath \ "worksNumber").read[String]
+    (__ \ "employmentId").read[UUID] and
+      (__ \ "startDate").read[LocalDate] and
+      (__ \ "endDate").readNullable[LocalDate] and
+      (__ \ "payeReference").read[String] and
+      (__ \ "employerName").read[String] and
+      (__ \ "companyBenefitsURI").readNullable[String] and
+      (__ \ "payAndTaxURI").readNullable[String] and
+      (__ \ "employmentURI").readNullable[String] and
+      (__ \ "employmentPaymentType").readNullable[EmploymentPaymentType] and
+      __.read[EmploymentStatus] and
+      (__ \ "worksNumber").read[String]
     ) (Employment.apply _)
 
 
-  implicit val locationWrites: Writes[Employment] = (
-    (JsPath \ "employmentId").write[UUID] and
-      (JsPath \ "startDate").write[LocalDate] and
-      (JsPath \ "endDate").writeNullable[LocalDate] and
-      (JsPath \ "payeReference").write[String] and
-      (JsPath \ "employerName").write[String] and
-      (JsPath \ "companyBenefitsURI").writeNullable[String] and
-      (JsPath \ "payAndTaxURI").writeNullable[String] and
-      (JsPath \ "employmentURI").writeNullable[String] and
-      (JsPath \ "receivingOccupationalPension").write[Boolean] and
-      (JsPath \ "receivingJobSeekersAllowance").write[Boolean] and
-      (JsPath \ "employmentPaymentType").writeNullable[EmploymentPaymentType] and
-      JsPath.write[EmploymentStatus] and
-      (JsPath \ "worksNumber").write[String]
+  implicit val jsonWrites: Writes[Employment] = (
+    (__ \ "employmentId").write[UUID] and
+      (__ \ "startDate").write[LocalDate] and
+      (__ \ "endDate").writeNullable[LocalDate] and
+      (__ \ "payeReference").write[String] and
+      (__ \ "employerName").write[String] and
+      (__ \ "companyBenefitsURI").writeNullable[String] and
+      (__ \ "payAndTaxURI").writeNullable[String] and
+      (__ \ "employmentURI").writeNullable[String] and
+      (__ \ "employmentPaymentType").writeNullable[EmploymentPaymentType] and
+      __.write[EmploymentStatus] and
+      (__ \ "worksNumber").write[String]
     ) (unlift(Employment.unapply))
 
 }

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -77,8 +77,8 @@ object Employment {
       (JsPath \ "employmentURI").readNullable[String] and
       (JsPath \ "receivingOccupationalPension").read[Boolean] and
       (JsPath \ "receivingJobSeekersAllowance").read[Boolean] and
-      JsPath.read[EmploymentStatus] and
       (JsPath \ "employmentPaymentType").readNullable[EmploymentPaymentType] and
+      JsPath.read[EmploymentStatus] and
       (JsPath \ "worksNumber").read[String]
     ) (Employment.apply _)
 

--- a/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/Employment.scala
@@ -62,7 +62,7 @@ object Employment {
     }
 
     Employment(startDate = startDate, endDate = overriddenEndDate, payeReference = noRecord, employerName = noRecord,
-      employmentStatus = EmploymentStatus.Unknown,  worksNumber = noRecord)
+      employmentPaymentType = None, employmentStatus = EmploymentStatus.Unknown,  worksNumber = noRecord)
 
   }
 

--- a/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
@@ -41,6 +41,21 @@ object EmploymentPaymentType {
 
   def unapply(paymentType: EmploymentPaymentType): Option[String] = Some(paymentType.name)
 
+  def paymentType(payeReference: String,
+            receivingOccupationalPension: Boolean,
+            receivingJobSeekersAllowance: Boolean): Option[EmploymentPaymentType] = {
+    if(receivingOccupationalPension)
+      Some(OccupationalPension)
+    else if (receivingJobSeekersAllowance)
+      Some(JobseekersAllowance)
+    else payeReference match {
+      case "892/BA500" => Some(IncapacityBenefit)
+      case "267/ESA500" => Some(EmploymentAndSupportAllowance)
+      case "267/LS500" => Some(StatePensionLumpSum)
+      case _ => None
+    }
+  }
+
   private implicit val reads: Reads[EmploymentPaymentType] = new Reads[EmploymentPaymentType] {
     override def reads(json: JsValue): JsResult[EmploymentPaymentType] = json match {
       case JsString(value)  => Try(JsSuccess(EmploymentPaymentType(value))).getOrElse(JsError(s"Invalid EmploymentPaymentType $value"))

--- a/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
@@ -1,0 +1,40 @@
+package uk.gov.hmrc.taxhistory.model.api
+
+import play.api.libs.json._
+
+import scala.util.Try
+
+sealed trait EmploymentPaymentType extends Product with Serializable {
+  val name: String
+}
+
+object EmploymentPaymentType {
+  case object OccupationalPension extends EmploymentPaymentType { val name = "OccupationalPension" }
+  case object JobseekersAllowance extends EmploymentPaymentType { val name = "JobseekersAllowance" }
+  case object IncapacityBenefit extends EmploymentPaymentType { val name = "IncapacityBenefit" }
+  case object EmploymentAndSupportAllowance extends EmploymentPaymentType { val name = "EmploymentAndSupportAllowance" }
+  case object StatePensionLumpSum extends EmploymentPaymentType { val name = "StatePensionLumpSum" }
+
+  def apply(name: String): EmploymentPaymentType = name.trim match {
+    case OccupationalPension.name => OccupationalPension
+    case JobseekersAllowance.name => JobseekersAllowance
+    case IncapacityBenefit.name => IncapacityBenefit
+    case EmploymentAndSupportAllowance.name => EmploymentAndSupportAllowance
+    case StatePensionLumpSum.name => StatePensionLumpSum
+  }
+
+  def unapply(paymentType: EmploymentPaymentType): Option[String] = Some(paymentType.name)
+
+  private implicit val reads: Reads[EmploymentPaymentType] = new Reads[EmploymentPaymentType] {
+    override def reads(json: JsValue): JsResult[EmploymentPaymentType] = json match {
+      case JsString(value)  => Try(JsSuccess(EmploymentPaymentType(value))).getOrElse(JsError(s"Invalid EmploymentPaymentType $value"))
+      case invalid => JsError(s"Invalid EmploymentPaymentType $invalid")
+    }
+  }
+
+  private implicit val writes: Writes[EmploymentPaymentType] = new Writes[EmploymentPaymentType] {
+    override def writes(o: EmploymentPaymentType): JsValue = JsString(o.name)
+  }
+
+  implicit val format: Format[EmploymentPaymentType] = Format[EmploymentPaymentType](reads, writes)
+}

--- a/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentType.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.taxhistory.model.api
 
 import play.api.libs.json._

--- a/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
@@ -44,8 +44,6 @@ case class NpsEmployment(nino: String,
       payeReference = payeRef,
       startDate = startDate,
       endDate = endDate,
-      receivingOccupationalPension = receivingOccupationalPension,
-      receivingJobSeekersAllowance = receivingJobSeekersAllowance,
       employmentPaymentType = employmentPaymentType,
       employmentStatus = employmentStatus,
       worksNumber = worksNumber.getOrElse("")

--- a/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
+++ b/app/uk/gov/hmrc/taxhistory/model/nps/NpsEmployment.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.taxhistory.model.nps
 
 import org.joda.time.LocalDate
 import play.api.libs.json._
-import uk.gov.hmrc.taxhistory.model.api.Employment
+import uk.gov.hmrc.taxhistory.model.api.{Employment, EmploymentPaymentType}
 import uk.gov.hmrc.taxhistory.model.utils.JsonUtils
 
 case class NpsEmployment(nino: String,
@@ -37,7 +37,8 @@ case class NpsEmployment(nino: String,
 
   def payeRef: String = taxDistrictNumber + "/" + payeNumber
 
-  def toEmployment: Employment =
+  def toEmployment: Employment ={
+    val employmentPaymentType = EmploymentPaymentType.paymentType(payeRef, receivingOccupationalPension, receivingJobSeekersAllowance)
     Employment(
       employerName = employerName,
       payeReference = payeRef,
@@ -45,10 +46,11 @@ case class NpsEmployment(nino: String,
       endDate = endDate,
       receivingOccupationalPension = receivingOccupationalPension,
       receivingJobSeekersAllowance = receivingJobSeekersAllowance,
+      employmentPaymentType = employmentPaymentType,
       employmentStatus = employmentStatus,
       worksNumber = worksNumber.getOrElse("")
     )
-
+  }
 }
 
 object NpsEmployment {

--- a/test/resources/json/model/api/employment.json
+++ b/test/resources/json/model/api/employment.json
@@ -4,8 +4,6 @@
   "employerName": "employer-1",
   "startDate": "2016-01-21",
   "endDate": "2017-01-01",
-  "receivingOccupationalPension": false,
-  "receivingJobSeekersAllowance": false,
   "employmentStatus":1,
   "worksNumber": "00191048716"
 }

--- a/test/resources/json/model/api/employmentNoEndDate.json
+++ b/test/resources/json/model/api/employmentNoEndDate.json
@@ -3,8 +3,6 @@
   "payeReference": "paye-2",
   "employerName": "employer-2",
   "startDate": "2016-02-22",
-  "receivingOccupationalPension": false,
-  "receivingJobSeekersAllowance": false,
   "employmentStatus":1,
   "worksNumber": "00191048716"
 }

--- a/test/resources/json/model/api/employments.json
+++ b/test/resources/json/model/api/employments.json
@@ -4,8 +4,6 @@
   "employerName": "employer-1",
   "startDate": "2016-01-21",
   "endDate": "2017-01-01",
-  "receivingOccupationalPension": false,
-  "receivingJobSeekersAllowance": false,
   "employmentStatus":1,
   "worksNumber": "00191048716"
 },{
@@ -13,8 +11,6 @@
   "payeReference": "paye-2",
   "employerName": "employer-2",
   "startDate": "2016-02-22",
-  "receivingOccupationalPension": false,
-  "receivingJobSeekersAllowance": false,
   "employmentStatus":1,
   "worksNumber": "00191048716"
 }]

--- a/test/resources/json/model/api/paye.json
+++ b/test/resources/json/model/api/paye.json
@@ -6,8 +6,6 @@
       "endDate": "2017-01-01",
       "payeReference": "paye-1",
       "employerName": "employer-1",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus": 1,
       "worksNumber": "00191048716"
     },
@@ -16,8 +14,6 @@
       "startDate": "2016-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus": 1,
       "worksNumber": "00191048716"
     }

--- a/test/resources/json/model/api/payeNoAllowances.json
+++ b/test/resources/json/model/api/payeNoAllowances.json
@@ -6,7 +6,6 @@
       "endDate": "2017-01-01",
       "payeReference": "paye-1",
       "employerName": "employer-1",
-      "receivingOccupationalPension": false,
       "employmentStatus":1
     },
     {
@@ -14,7 +13,6 @@
       "startDate": "2016-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
-      "receivingOccupationalPension": false,
       "employmentStatus":1
     }
   ],

--- a/test/resources/json/model/api/payeNoCompanyBenefits.json
+++ b/test/resources/json/model/api/payeNoCompanyBenefits.json
@@ -6,8 +6,6 @@
       "endDate": "2017-01-01",
       "payeReference": "paye-1",
       "employerName": "employer-1",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus":1,
       "worksNumber": "00191048716"
     },
@@ -16,8 +14,6 @@
       "startDate": "2016-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus":1,
       "worksNumber": "00191048716"
     }

--- a/test/resources/json/model/api/payeNoTaxAccount.json
+++ b/test/resources/json/model/api/payeNoTaxAccount.json
@@ -6,7 +6,6 @@
       "endDate": "2017-01-01",
       "payeReference": "paye-1",
       "employerName": "employer-1",
-      "receivingOccupationalPension": false,
       "employmentStatus": 1
     },
     {
@@ -14,7 +13,6 @@
       "startDate": "2016-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
-      "receivingOccupationalPension": false,
       "employmentStatus": 1
     }
   ],

--- a/test/resources/json/withPlaceholders/model/api/paye.json
+++ b/test/resources/json/withPlaceholders/model/api/paye.json
@@ -6,8 +6,6 @@
       "endDate": "%taxYearFinishYear%-02-21",
       "payeReference": "paye-1",
       "employerName": "employer-1",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus": 1,
       "worksNumber": "00191048716"
     },
@@ -16,8 +14,6 @@
       "startDate": "%taxYearFinishYear%-02-22",
       "payeReference": "paye-2",
       "employerName": "employer-2",
-      "receivingOccupationalPension": false,
-      "receivingJobSeekersAllowance": false,
       "employmentStatus": 1,
       "worksNumber": "00191048716"
     }

--- a/test/uk/gov/hmrc/taxhistory/controllers/PayAsYouEarnControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/controllers/PayAsYouEarnControllerSpec.scala
@@ -160,8 +160,6 @@ class PayAsYouEarnControllerSpec extends PlaySpec with OneServerPerSuite with Mo
                |      "startDate":"${testStartDate.toString}",
                |      "payeReference":"SOME_PAYE",
                |      "employerName":"Megacorp Plc",
-               |      "receivingOccupationalPension":false,
-               |      "receivingJobSeekersAllowance":false,
                |      "employmentStatus":1,
                |      "worksNumber":"00191048716"
                |    }

--- a/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
+++ b/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
@@ -26,31 +26,52 @@ trait Employments {
 
   val testWorksNumber = "00191048716"
 
-  val liveOngoingEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, None, "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Live, testWorksNumber)
+  private def templateEmployment = Employment(
+    employmentId = UUID.randomUUID(),
+    startDate = TaxYear.current.starts,
+    endDate = None,
+    payeReference = "Nothing",
+    employerName = "An Employer",
+    None, None, None, false, false, None,
+    employmentStatus = EmploymentStatus.Live,
+    testWorksNumber)
 
-  val liveNoEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(30), None, "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Live, testWorksNumber)
+  val liveOngoingEmployment = templateEmployment
 
-  val liveStartYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts, Some(TaxYear.current.starts.plusDays(10)), "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Live, testWorksNumber)
+  val liveNoEndEmployment = templateEmployment.copy(startDate = TaxYear.current.starts.plusDays(30))
 
-  val liveMidYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(40) , Some(TaxYear.current.finishes.minusDays(10)), "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Live, testWorksNumber)
+  val liveStartYearEmployment = templateEmployment.copy(endDate = Some(TaxYear.current.starts.plusDays(10)))
 
-  val liveEndYearEmployment = Employment(UUID.randomUUID(), TaxYear.current.finishes.minusDays(10) , Some(TaxYear.current.finishes), "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Live, testWorksNumber)
+  val liveMidYearEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.starts.plusDays(40),
+    endDate = Some(TaxYear.current.finishes.minusDays(10))
+  )
 
-  val ceasedBeforeStartEmployment = Employment(UUID.randomUUID(), TaxYear.current.previous.starts.plusDays(5) , Some(TaxYear.current.starts.plusDays(30)), "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Ceased, testWorksNumber)
+  val liveEndYearEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.finishes.minusDays(10),
+    endDate = Some(TaxYear.current.finishes)
+  )
 
-  val ceasedNoEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(90) , None, "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Ceased, testWorksNumber)
+  val ceasedBeforeStartEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.previous.starts.plusDays(5) ,
+    endDate = Some(TaxYear.current.starts.plusDays(30)),
+    employmentStatus = EmploymentStatus.Ceased
+  )
 
-  val ceasedAfterEndEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(60), Some(TaxYear.current.next.starts.plusDays(30)), "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.Ceased, testWorksNumber)
+  val ceasedNoEndEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.starts.plusDays(90),
+    employmentStatus = EmploymentStatus.Ceased
+  )
 
-  val potentiallyCeasedEmployment = Employment(UUID.randomUUID(), TaxYear.current.starts.plusDays(90) , None, "Nothing", "An Employer",
-    None, None, None, false, false, EmploymentStatus.PotentiallyCeased, testWorksNumber)
+  val ceasedAfterEndEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.starts.plusDays(60),
+    endDate = Some(TaxYear.current.next.starts.plusDays(30)),
+    employmentStatus = EmploymentStatus.Ceased
+  )
+
+  val potentiallyCeasedEmployment = templateEmployment.copy(
+    startDate = TaxYear.current.starts.plusDays(90),
+    employmentStatus = EmploymentStatus.PotentiallyCeased
+  )
 
 }

--- a/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
+++ b/test/uk/gov/hmrc/taxhistory/fixtures/Employments.scala
@@ -32,7 +32,7 @@ trait Employments {
     endDate = None,
     payeReference = "Nothing",
     employerName = "An Employer",
-    None, None, None, false, false, None,
+    None, None, None, None,
     employmentStatus = EmploymentStatus.Live,
     testWorksNumber)
 

--- a/test/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentTypeSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentTypeSpec.scala
@@ -51,6 +51,24 @@ class EmploymentPaymentTypeSpec extends TestUtil with UnitSpec {
       }
     }
   }
+
+  "calling paymentType" should {
+    "return JobSeekersAllowance if 'receivingJobseekersAllowance' flag is true" in {
+      paymentType("123/AB123", false, receivingJobSeekersAllowance = true) shouldBe Some(JobseekersAllowance)
+    }
+    "return OccupationalPension if 'receivingOccupationalPension' flag is true" in {
+      paymentType("123/AB123", receivingOccupationalPension = true, false) shouldBe Some(OccupationalPension)
+    }
+    "return IncapacityBenefit if PAYE reference is '892/BA500'" in {
+      paymentType("892/BA500", false, false) shouldBe Some(IncapacityBenefit)
+    }
+    "return EmploymentAndSupportAllowance if PAYE reference is '267/ESA500'" in {
+      paymentType("267/ESA500", false, false) shouldBe Some(EmploymentAndSupportAllowance)
+    }
+    "return StatePensionLumpSum if PAYE reference is '267/LS500'" in {
+      paymentType("267/LS500", false, false) shouldBe Some(StatePensionLumpSum)
+    }
+  }
 }
 
 

--- a/test/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentTypeSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/api/EmploymentPaymentTypeSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.taxhistory.model.api
+
+import play.api.libs.json.Json._
+import play.api.libs.json.{JsObject, _}
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType._
+import uk.gov.hmrc.taxhistory.model.utils.TestUtil
+
+class EmploymentPaymentTypeSpec extends TestUtil with UnitSpec {
+
+  case class TestObj(employmentPaymentType: Option[EmploymentPaymentType])
+  implicit val testObjFormat = Json.format[TestObj]
+
+  "EmploymentPaymentType" when {
+    "(de)serialising an 'employmentPaymentType' field" should {
+
+      "serialise to a missing field when the optional EmploymentPaymentType is empty" in {
+        val noPaymentType = TestObj(employmentPaymentType = None)
+        (toJson(noPaymentType) \ "employmentPaymentType") shouldBe a[JsUndefined]
+      }
+      "serialise to a json object when there is some EmploymentPaymentType present" in {
+        val serialisedObj = Json.parse("""{ "employmentPaymentType": "OccupationalPension" }""")
+        toJson(TestObj(employmentPaymentType = Some(OccupationalPension))) shouldBe serialisedObj
+      }
+      "deserialise from a missing field to a None" in {
+        fromJson[TestObj](Json.parse("{}")).get shouldBe TestObj(None)
+      }
+      "deserialise from a field with valid value to some EmploymentPaymentType" in {
+        val serialisedObj = Json.parse("""{ "employmentPaymentType": "OccupationalPension" }""")
+        fromJson[TestObj](serialisedObj).get shouldBe TestObj(Some(OccupationalPension))
+      }
+      "throw an exception when deserialising from a field with invalid value" in {
+        val serialisedObj = Json.parse("""{ "employmentPaymentType": "SomethingPeculiar" }""")
+        fromJson[TestObj](serialisedObj) shouldBe a[JsError]
+      }
+    }
+  }
+}
+
+

--- a/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
@@ -50,6 +50,7 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
         payeReference = "paye-1",
         employerName = "employer-1",
         employmentStatus = EmploymentStatus.Live,
+        employmentPaymentType = Some(EmploymentPaymentType.IncapacityBenefit),
         worksNumber = "00191048716"
       )
       val employments1Json = Json.parse(
@@ -62,6 +63,7 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
           |      "employerName": "employer-1",
           |      "receivingOccupationalPension": false,
           |      "receivingJobSeekersAllowance": false,
+          |      "employmentPaymentType": "IncapacityBenefit",
           |      "employmentStatus": 1,
           |      "worksNumber": "00191048716"
           |    }
@@ -74,6 +76,7 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
         payeReference = "paye-2",
         employerName = "employer-2",
         employmentStatus = EmploymentStatus.Live,
+        employmentPaymentType = None,
         worksNumber = "00191048716"
       )
       val employments2Json = Json.parse(

--- a/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/model/api/PayAsYouEarnSpec.scala
@@ -61,8 +61,6 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
           |      "endDate": "2017-01-01",
           |      "payeReference": "paye-1",
           |      "employerName": "employer-1",
-          |      "receivingOccupationalPension": false,
-          |      "receivingJobSeekersAllowance": false,
           |      "employmentPaymentType": "IncapacityBenefit",
           |      "employmentStatus": 1,
           |      "worksNumber": "00191048716"
@@ -86,8 +84,6 @@ class PayAsYouEarnSpec extends TestUtil with UnitSpec {
           |      "startDate": "2016-02-22",
           |      "payeReference": "paye-2",
           |      "employerName": "employer-2",
-          |      "receivingOccupationalPension": false,
-          |      "receivingJobSeekersAllowance": false,
           |      "employmentStatus": 1,
           |      "worksNumber": "00191048716"
           |    }

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -355,14 +355,14 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
-          receivingOccupationalPension = false, receivingJobSeekersAllowance = false, Live, "00191048716")
+          receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
 
       val testEmployment3 = Employment(UUID.fromString("019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
         locaDateCyMinus1("02", "22"), None, "paye-2", "employer-2",
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/company-benefits"),
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/pay-and-tax"),
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
-        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, Live, "00191048716")
+        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
 
       // Set up the test data in the cache
       await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), taxYear), paye))
@@ -394,7 +394,7 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
-        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, Live, "00191048716")
+        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
 
       await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), TaxYear(2014)), paye))
 

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -157,7 +157,7 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
       employments.head.payeReference shouldBe "531/J4816"
       employments.head.startDate shouldBe startDate
       employments.head.endDate shouldBe None
-      employments.head.employmentPaymentType shouldBe None
+      employments.head.employmentPaymentType shouldBe Some(OccupationalPension)
 
       val Some(payAndTax) = paye.payAndTax.get(employments.head.employmentId.toString)
       payAndTax.taxablePayTotal shouldBe Some(BigDecimal.valueOf(20000.00))

--- a/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/EmploymentHistoryServiceSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, NotFoundException}
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.tai.model.rti.{RtiData, RtiEmployment}
 import uk.gov.hmrc.taxhistory.fixtures.Employments
+import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType.OccupationalPension
 import uk.gov.hmrc.taxhistory.model.api.{CompanyBenefit, Employment, PayAsYouEarn}
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus.Live
 import uk.gov.hmrc.taxhistory.model.nps.{EmploymentStatus, Iabd, NpsEmployment, NpsTaxAccount}
@@ -156,6 +157,7 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
       employments.head.payeReference shouldBe "531/J4816"
       employments.head.startDate shouldBe startDate
       employments.head.endDate shouldBe None
+      employments.head.employmentPaymentType shouldBe None
 
       val Some(payAndTax) = paye.payAndTax.get(employments.head.employmentId.toString)
       payAndTax.taxablePayTotal shouldBe Some(BigDecimal.valueOf(20000.00))
@@ -208,7 +210,8 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
       employment.payeReference shouldBe "531/J4816"
       employment.startDate shouldBe startDate
       employment.endDate shouldBe None
-      employment.receivingOccupationalPension shouldBe true
+      employment.isOccupationalPension shouldBe true
+      employment.employmentPaymentType shouldBe Some(OccupationalPension)
       payAndTax.taxablePayTotal shouldBe Some(BigDecimal.valueOf(20000.00))
       payAndTax.taxablePayTotalIncludingEYU shouldBe Some(BigDecimal.valueOf(19399.01))
       payAndTax.taxTotal shouldBe Some(BigDecimal.valueOf(1880.00))
@@ -355,14 +358,14 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
           Some(s"/${taxYear.startYear}/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
-          receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
+          None, Live, "00191048716")
 
       val testEmployment3 = Employment(UUID.fromString("019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
         locaDateCyMinus1("02", "22"), None, "paye-2", "employer-2",
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/company-benefits"),
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87/pay-and-tax"),
         Some(s"/${taxYear.startYear}/employments/019f5fee-d5e4-4f3e-9569-139b8ad81a87"),
-        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
+        None, Live, "00191048716")
 
       // Set up the test data in the cache
       await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), taxYear), paye))
@@ -394,7 +397,7 @@ class EmploymentHistoryServiceSpec extends UnitSpec with MockitoSugar with TestU
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/company-benefits"),
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3/pay-and-tax"),
         Some("/2014/employments/01318d7c-bcd9-47e2-8c38-551e7ccdfae3"),
-        receivingOccupationalPension = false, receivingJobSeekersAllowance = false, None, Live, "00191048716")
+        None, Live, "00191048716")
 
       await(testEmploymentHistoryService.cacheService.insertOrUpdate((Nino("AA000000A"), TaxYear(2014)), paye))
 

--- a/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.domain.TaxCode
 import uk.gov.hmrc.tai.model.rti.RtiData
+import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType.{JobseekersAllowance, OccupationalPension, StatePensionLumpSum}
 import uk.gov.hmrc.taxhistory.model.api._
 import uk.gov.hmrc.taxhistory.model.nps.EmploymentStatus.Live
 import uk.gov.hmrc.taxhistory.model.nps._
@@ -232,6 +233,30 @@ class EmploymentHistoryServiceHelperSpec extends PlaySpec with MockitoSugar with
       payAndTax.get.earlierYearUpdates.size mustBe 1
       val companyBenefits = payAsYouEarn.benefits.get(employment.employmentId.toString)
       companyBenefits mustBe None
+    }
+
+    "Employments employmentPaymentType is determined from the NPS employment's properties" when {
+      "NPS employment has receivingJobseekersAllowance flag set to true" in {
+        val npsEmployment = npsEmploymentResponseWithTaxDistrictNumber.head.copy(receivingJobSeekersAllowance = true)
+        val payAsYouEarn = EmploymentHistoryServiceHelper.buildPAYE(testRtiData.employments.headOption, Nil, Some(testIncomeSource), npsEmployment)
+        payAsYouEarn.employments.head.employmentPaymentType mustBe Some(JobseekersAllowance)
+
+      }
+      "NPS employment has receivingOccupantionalPension flag set to true" in {
+        val npsEmployment = npsEmploymentResponseWithTaxDistrictNumber.head.copy(receivingOccupationalPension = true)
+        val payAsYouEarn = EmploymentHistoryServiceHelper.buildPAYE(testRtiData.employments.headOption, Nil, Some(testIncomeSource), npsEmployment)
+        payAsYouEarn.employments.head.employmentPaymentType mustBe Some(OccupationalPension)
+      }
+      "NPS employment has a recognised PAYE reference" in {
+        val npsEmployment = npsEmploymentResponseWithTaxDistrictNumber.head.copy(taxDistrictNumber = "267", payeNumber = "LS500")
+        val payAsYouEarn = EmploymentHistoryServiceHelper.buildPAYE(testRtiData.employments.headOption, Nil, Some(testIncomeSource), npsEmployment)
+        payAsYouEarn.employments.head.employmentPaymentType mustBe Some(StatePensionLumpSum)
+      }
+      "NPS employment has no properties that signal a special employment type" in {
+        val npsEmployment = npsEmploymentResponseWithTaxDistrictNumber.head
+        val payAsYouEarn = EmploymentHistoryServiceHelper.buildPAYE(testRtiData.employments.headOption, Nil, Some(testIncomeSource), npsEmployment)
+        payAsYouEarn.employments.head.employmentPaymentType mustBe None
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
+++ b/test/uk/gov/hmrc/taxhistory/services/helper/EmploymentHistoryServiceHelperSpec.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.taxhistory.services.helper
 import org.joda.time.LocalDate
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import uk.gov.hmrc.domain.TaxCode
 import uk.gov.hmrc.tai.model.rti.RtiData
 import uk.gov.hmrc.taxhistory.model.api.EmploymentPaymentType.{JobseekersAllowance, OccupationalPension, StatePensionLumpSum}
 import uk.gov.hmrc.taxhistory.model.api._


### PR DESCRIPTION
 'employmentPaymentType' can be one of "OccupationalPension", "JobseekersAllowance", "IncapacityBenefit", "EmploymentAndSupportAllowance", and "StatePensionLumpSum".
It replaces the 'receivingOccupationalPension' and 'receivingJobseekersAllowance' flags on the employments.