### PR TITLE
DDCE-2156: update logging config

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -7,7 +7,13 @@
 
     <logger name="uk.gov" level="${logger.uk.gov:-INFO}"/>
 
-    <logger name="application" level="${logger.application:-INFO}"/>
+    <!--  uses the default "application" logger level: http://logback.qos.ch/manual/configuration.html#defaultValuesForVariables  -->
+    <logger name="application"  level="${logger.application:-INFO}"/>
+    <logger name="connectors"   level="${logger.application:-INFO}"/>
+    <logger name="controllers"  level="${logger.application:-INFO}"/>
+    <logger name="model"        level="${logger.application:-INFO}"/>
+    <logger name="services"     level="${logger.application:-INFO}"/>
+    <logger name="utils"        level="${logger.application:-INFO}"/>
 
     <logger name="com.ning.http.client" level="WARN"/>
 
@@ -17,7 +23,8 @@
 
     <logger name="play.core.netty" additivity="false" level="WARN"/>
 
-    <root level="${logger.application:-ERROR}">
+    <!--  use the root level from the default logback config? default to INFO  -->
+    <root level="${logger.root:-INFO}">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -47,7 +47,13 @@
 
     <logger name="uk.gov" level="INFO"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application"  level="DEBUG"/>
+    <!--  default to INFO logging level  -->
+    <logger name="connectors"   level="INFO"/>
+    <logger name="controllers"  level="INFO"/>
+    <logger name="model"        level="INFO"/>
+    <logger name="services"     level="INFO"/>
+    <logger name="utils"        level="INFO"/>
 
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
JSON logger appeared to be configured to only output `ERROR` level: lowered to `INFO`.
"application" logger added as a default for the log levels following